### PR TITLE
errors(postgresql): Clarify missing ledger state delta message.

### DIFF
--- a/conduit/plugins/exporters/postgresql/postgresql_exporter.go
+++ b/conduit/plugins/exporters/postgresql/postgresql_exporter.go
@@ -3,6 +3,7 @@ package postgresql
 import (
 	"context"
 	_ "embed" // used to embed config
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -25,6 +26,8 @@ import (
 
 // PluginName to use when configuring.
 const PluginName = "postgresql"
+
+var errMissingDelta = errors.New("ledger state delta is missing from block, ensure algod importer is using 'follower' mode")
 
 type postgresqlExporter struct {
 	round  uint64
@@ -120,7 +123,7 @@ func (exp *postgresqlExporter) Receive(exportData data.BlockData) error {
 		if exportData.Round() == 0 {
 			exportData.Delta = &sdk.LedgerStateDelta{}
 		} else {
-			return fmt.Errorf("receive got an invalid block: %#v", exportData)
+			return errMissingDelta
 		}
 	}
 	// Do we need to test for consensus protocol here?

--- a/conduit/plugins/exporters/postgresql/postgresql_exporter_test.go
+++ b/conduit/plugins/exporters/postgresql/postgresql_exporter_test.go
@@ -2,7 +2,6 @@ package postgresql
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -80,8 +79,8 @@ func TestReceiveInvalidBlock(t *testing.T) {
 		Certificate: &map[string]interface{}{},
 		Delta:       nil,
 	}
-	expectedErr := fmt.Sprintf("receive got an invalid block: %#v", invalidBlock)
-	assert.EqualError(t, pgsqlExp.Receive(invalidBlock), expectedErr)
+	err := pgsqlExp.Receive(invalidBlock)
+	assert.ErrorIs(t, err, errMissingDelta)
 }
 
 func TestReceiveAddBlockSuccess(t *testing.T) {


### PR DESCRIPTION
## Summary

If the postgresql exporter is given a block without a ledger state delta object, the error message gave no indication about what the user should do. Attempt to clarify the situation by telling the user to check that their algod importer is in follower mode.

## Test Plan

Update existing unit test.