### PR TITLE
conduit-docs: conduit_processors_filter_tags.md

### DIFF
--- a/conduit/plugins/processors/filterprocessor/fields/searcher.go
+++ b/conduit/plugins/processors/filterprocessor/fields/searcher.go
@@ -1,6 +1,6 @@
 package fields
 
-//go:generate go run ../gen/generate.go fields ./generated_signed_txn_map.go
+//go:generate go run ../gen/generate.go fields ./generated_signed_txn_map.go ../../../../../conduit-docs/conduit_processors_filter_tags.md
 
 import (
 	"fmt"


### PR DESCRIPTION
tag is one of the config field for filter processor. It would be convenient to have a list of supported tags in the conduit docs.  
the doc would have a table like this, 
|filter tag|transaction field|
| -------- | ------- |
|aca|ApplyData.AssetClosingAmount|
|apid|ApplyData.ApplicationID|
|ca|ApplyData.ClosingAmount|
|caid|ApplyData.ConfigAsset|
|lsig.msig.thr|SignedTxn.Lsig.Msig.Threshold|
|lsig.msig.v|SignedTxn.Lsig.Msig.Version|
|msig.thr|SignedTxn.Msig.Threshold|
|msig.v|SignedTxn.Msig.Version|
|rc|ApplyData.CloseRewards|
|rr|ApplyData.ReceiverRewards|
|...||