### PR TITLE
postgres exporter: Add export stat log message matching the old log m…

### DIFF
--- a/conduit/pipeline/pipeline.go
+++ b/conduit/pipeline/pipeline.go
@@ -460,6 +460,7 @@ func (p *pipelineImpl) Start() {
 						retry++
 						goto pipelineRun
 					}
+					p.logger.Infof("round r=%d (%d txn) exported in %s", p.pipelineMetadata.NextRound, len(blkData.Payset), time.Since(start))
 
 					// Increment Round, update metadata
 					p.pipelineMetadata.NextRound++

--- a/conduit/plugins/exporters/postgresql/postgresql_exporter.go
+++ b/conduit/plugins/exporters/postgresql/postgresql_exporter.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -120,7 +119,6 @@ func (exp *postgresqlExporter) Close() error {
 }
 
 func (exp *postgresqlExporter) Receive(exportData data.BlockData) error {
-	start := time.Now()
 	if exportData.Delta == nil {
 		if exportData.Round() == 0 {
 			exportData.Delta = &sdk.LedgerStateDelta{}
@@ -136,7 +134,6 @@ func (exp *postgresqlExporter) Receive(exportData data.BlockData) error {
 		return err
 	}
 
-	exp.logger.Infof("round r=%d (%d txn) imported in %s", exportData.Round(), len(exportData.Payset), time.Since(start))
 	atomic.StoreUint64(&exp.round, exportData.Round()+1)
 	return nil
 }

--- a/conduit/plugins/exporters/postgresql/postgresql_exporter.go
+++ b/conduit/plugins/exporters/postgresql/postgresql_exporter.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -119,6 +120,7 @@ func (exp *postgresqlExporter) Close() error {
 }
 
 func (exp *postgresqlExporter) Receive(exportData data.BlockData) error {
+	start := time.Now()
 	if exportData.Delta == nil {
 		if exportData.Round() == 0 {
 			exportData.Delta = &sdk.LedgerStateDelta{}
@@ -133,6 +135,8 @@ func (exp *postgresqlExporter) Receive(exportData data.BlockData) error {
 	if err := exp.db.AddBlock(&vb); err != nil {
 		return err
 	}
+
+	exp.logger.Infof("round r=%d (%d txn) imported in %s", exportData.Round(), len(exportData.Payset), time.Since(start))
 	atomic.StoreUint64(&exp.round, exportData.Round()+1)
 	return nil
 }

--- a/conduit/plugins/exporters/postgresql/postgresql_exporter.go
+++ b/conduit/plugins/exporters/postgresql/postgresql_exporter.go
@@ -133,7 +133,6 @@ func (exp *postgresqlExporter) Receive(exportData data.BlockData) error {
 	if err := exp.db.AddBlock(&vb); err != nil {
 		return err
 	}
-
 	atomic.StoreUint64(&exp.round, exportData.Round()+1)
 	return nil
 }


### PR DESCRIPTION
## Summary

This is the format is similar to the one Indexer currently uses for printing postgres stats. It's still useful for Conduit.