### PR TITLE
release: Goreleaser configuration and automation.

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,30 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - 'v1.**'
+
+permissions:
+  contents: write
+  # packages: write
+  # issues: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,39 @@
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+universal_binaries:
+  - replace: true
+builds:
+  - main: /cmd/conduit/main.go
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    ldflags: >
+      -s -w
+      -X github.com/algorand/conduit/version.Hash={{.FullCommit}}
+      -X github.com/algorand/conduit/version.CompileTime={{.Timestamp}}
+      -X github.com/algorand/indexer/version.ReleaseVersion={{.Version}}
+
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ before:
 universal_binaries:
   - replace: true
 builds:
-  - main: /cmd/conduit/main.go
+  - main: cmd/conduit/main.go
     env:
       - CGO_ENABLED=0
     goos:
@@ -17,8 +17,10 @@ builds:
     ldflags: >
       -s -w
       -X github.com/algorand/conduit/version.Hash={{.FullCommit}}
+      -X github.com/algorand/conduit/version.ShortHash={{.ShortCommit}}
       -X github.com/algorand/conduit/version.CompileTime={{.Timestamp}}
-      -X github.com/algorand/indexer/version.ReleaseVersion={{.Version}}
+      -X github.com/algorand/conduit/version.ReleaseVersion={{.Version}}
+    
 
 archives:
   - replacements:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,8 +4,11 @@ before:
     - go mod tidy
     # you may remove this if you don't need go generate
     - go generate ./...
+
+# Build mac universal binary.
 universal_binaries:
   - replace: true
+
 builds:
   - main: cmd/conduit/main.go
     env:
@@ -14,20 +17,22 @@ builds:
       - linux
       - windows
       - darwin
+    # skip 386 architecture.
+    goarch:
+      - amd64
+      - arm64
     ldflags: >
       -s -w
       -X github.com/algorand/conduit/version.Hash={{.FullCommit}}
       -X github.com/algorand/conduit/version.ShortHash={{.ShortCommit}}
       -X github.com/algorand/conduit/version.CompileTime={{.Timestamp}}
       -X github.com/algorand/conduit/version.ReleaseVersion={{.Version}}
-    
 
 archives:
   - replacements:
       darwin: Darwin
       linux: Linux
       windows: Windows
-      386: i386
       amd64: x86_64
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,5 +42,6 @@ changelog:
   sort: asc
   filters:
     exclude:
+      - '^chore:'
       - '^docs:'
       - '^test:'

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,9 @@ export GOPATH := $(shell go env GOPATH)
 GOPATH1 := $(firstword $(subst :, ,$(GOPATH)))
 
 # TODO: ensure any additions here are mirrored in misc/release.py
-GOLDFLAGS += -X github.com/algorand/indexer/version.Hash=$(shell git log -n 1 --pretty="%H")
-GOLDFLAGS += -X github.com/algorand/indexer/version.Dirty=$(if $(filter $(strip $(shell git status --porcelain|wc -c)), "0"),,true)
-GOLDFLAGS += -X github.com/algorand/indexer/version.CompileTime=$(shell date -u +%Y-%m-%dT%H:%M:%S%z)
-GOLDFLAGS += -X github.com/algorand/indexer/version.GitDecorateBase64=$(shell git log -n 1 --pretty="%D"|base64|tr -d ' \n')
-#GOLDFLAGS += -X github.com/algorand/indexer/version.ReleaseVersion=$(shell cat .version)
+GOLDFLAGS += -X github.com/algorand/conduit/version.Hash=$(shell git log -n 1 --pretty="%H")
+GOLDFLAGS += -X github.com/algorand/conduit/version.CompileTime=$(shell date -u +%Y-%m-%dT%H:%M:%S%z)
+GOLDFLAGS += -X github.com/algorand/indexer/version.ReleaseVersion="makefile"
 
 COVERPKG := $(shell go list ./...  | grep -v '/cmd/' | egrep -v '(testing|test|mocks)$$' |  paste -s -d, - )
 

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ SRCPATH		:= $(shell pwd)
 export GOPATH := $(shell go env GOPATH)
 GOPATH1 := $(firstword $(subst :, ,$(GOPATH)))
 
-# TODO: ensure any additions here are mirrored in misc/release.py
 GOLDFLAGS += -X github.com/algorand/conduit/version.Hash=$(shell git log -n 1 --pretty="%H")
+GOLDFLAGS += -X github.com/algorand/conduit/version.ShortHash=$(shell git log -n 1 --pretty="%h")
 GOLDFLAGS += -X github.com/algorand/conduit/version.CompileTime=$(shell date -u +%Y-%m-%dT%H:%M:%S%z)
-GOLDFLAGS += -X github.com/algorand/indexer/version.ReleaseVersion="makefile"
+GOLDFLAGS += -X "github.com/algorand/conduit/version.ReleaseVersion=Dev Build"
 
 COVERPKG := $(shell go list ./...  | grep -v '/cmd/' | egrep -v '(testing|test|mocks)$$' |  paste -s -d, - )
 
@@ -16,7 +16,7 @@ export GO_IMAGE = golang:$(shell go version | cut -d ' ' -f 3 | tail -c +3 )
 all: conduit
 
 conduit:
-	go generate ./... && cd cmd/conduit && go build -ldflags="${GOLDFLAGS}"
+	go generate ./... && cd cmd/conduit && go build -ldflags='${GOLDFLAGS}'
 
 # check that all packages (except tests) compile
 check:

--- a/cmd/conduit/main.go
+++ b/cmd/conduit/main.go
@@ -10,8 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 
-	"github.com/algorand/indexer/version"
-
 	"github.com/algorand/conduit/cmd/conduit/internal/initialize"
 	"github.com/algorand/conduit/cmd/conduit/internal/list"
 	"github.com/algorand/conduit/conduit"
@@ -20,6 +18,7 @@ import (
 	_ "github.com/algorand/conduit/conduit/plugins/exporters/all"
 	_ "github.com/algorand/conduit/conduit/plugins/importers/all"
 	_ "github.com/algorand/conduit/conduit/plugins/processors/all"
+	"github.com/algorand/conduit/version"
 )
 
 var (
@@ -59,6 +58,7 @@ func runConduitCmdWithConfig(args *conduit.Args) error {
 		return fmt.Errorf("runConduitCmdWithConfig(): failed to create logger: %w", err)
 	}
 
+	logger.Infof("Starting Conduit %s", version.LongVersion())
 	logger.Infof("Using data directory: %s", args.ConduitDataDir)
 	logger.Info("Conduit configuration is valid")
 
@@ -109,7 +109,6 @@ func makeConduitCmd() *cobra.Command {
 		},
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if vFlag {
-				fmt.Println("Conduit Pre-Release")
 				fmt.Printf("%s\n", version.LongVersion())
 				os.Exit(0)
 			}

--- a/version/strings.go
+++ b/version/strings.go
@@ -1,0 +1,70 @@
+package version
+
+import (
+	"encoding/base64"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// These are targets for compiling in build information.
+// See the top level Makefile and cmd/algorand-indexer/main.go
+
+var (
+	// Hash Git commit hash. Output of `git log -n 1 --pretty="%H"`
+	Hash string
+
+	// Dirty "true" or ""
+	// A release build should have no modified files and no unknown files.
+	Dirty string
+
+	// CompileTime YYYY-mm-ddTHH:MM:SS+ZZZZ
+	CompileTime string
+
+	// GitDecorateBase64 Decorations of latest commit which may include tags. Output of `git log -n 1 --pretty="%D"|base64`
+	GitDecorateBase64 string
+
+	// ReleaseVersion What was in /.version when this was compiled.
+	ReleaseVersion string
+)
+
+// UnknownVersion is used when the version is not known.
+const UnknownVersion = "(unknown version)"
+
+// Version the binary version.
+func Version() string {
+	// parse "tag: 1.2.3" out of the result of `git log -n 1 --pretty="%D"|base64`
+	if len(GitDecorateBase64) == 0 {
+		return UnknownVersion
+	}
+	b, err := base64.StdEncoding.DecodeString(GitDecorateBase64)
+	if err != nil {
+		return fmt.Sprintf("compiled with bad GitDecorateBase64, %s", err.Error())
+	}
+	tre := regexp.MustCompile(`tag:\s+([^,]+)`)
+	m := tre.FindAllStringSubmatch(string(b), -1)
+	if m == nil {
+		return UnknownVersion
+	}
+	for _, group := range m {
+		if len(group[1]) > 0 {
+			return strings.TrimSpace(group[1])
+		}
+	}
+	return UnknownVersion
+}
+
+// LongVersion the long form of the binary version.
+func LongVersion() string {
+	dirtyStr := ""
+	if (len(Dirty) > 0) && (Dirty != "false") {
+		dirtyStr = " (modified)"
+	}
+	tagVersion := Version()
+	if tagVersion == UnknownVersion {
+		tagVersion = fmt.Sprintf("%s-dev.unknown", ReleaseVersion)
+	} else if tagVersion != ReleaseVersion {
+		tagVersion = fmt.Sprintf("dev release build .version=%s tag=%s", ReleaseVersion, tagVersion)
+	}
+	return fmt.Sprintf("%s compiled at %s from git hash %s%s", tagVersion, CompileTime, Hash, dirtyStr)
+}

--- a/version/strings.go
+++ b/version/strings.go
@@ -5,7 +5,7 @@ import (
 )
 
 // These are targets for compiling in build information.
-// See the top level Makefile and cmd/algorand-indexer/main.go
+// They are set by the Makefile and .goreleaser.yml
 
 var (
 	// Hash git commit hash.

--- a/version/strings.go
+++ b/version/strings.go
@@ -1,30 +1,23 @@
 package version
 
 import (
-	"encoding/base64"
 	"fmt"
-	"regexp"
-	"strings"
 )
 
 // These are targets for compiling in build information.
 // See the top level Makefile and cmd/algorand-indexer/main.go
 
 var (
-	// Hash Git commit hash. Output of `git log -n 1 --pretty="%H"`
+	// Hash git commit hash.
 	Hash string
 
-	// Dirty "true" or ""
-	// A release build should have no modified files and no unknown files.
-	Dirty string
+	// ShortHash git commit short hash.
+	ShortHash string
 
-	// CompileTime YYYY-mm-ddTHH:MM:SS+ZZZZ
+	// CompileTime of the binary.
 	CompileTime string
 
-	// GitDecorateBase64 Decorations of latest commit which may include tags. Output of `git log -n 1 --pretty="%D"|base64`
-	GitDecorateBase64 string
-
-	// ReleaseVersion What was in /.version when this was compiled.
+	// ReleaseVersion based on release tag.
 	ReleaseVersion string
 )
 
@@ -33,38 +26,17 @@ const UnknownVersion = "(unknown version)"
 
 // Version the binary version.
 func Version() string {
-	// parse "tag: 1.2.3" out of the result of `git log -n 1 --pretty="%D"|base64`
-	if len(GitDecorateBase64) == 0 {
+	if ReleaseVersion == "" {
 		return UnknownVersion
 	}
-	b, err := base64.StdEncoding.DecodeString(GitDecorateBase64)
-	if err != nil {
-		return fmt.Sprintf("compiled with bad GitDecorateBase64, %s", err.Error())
-	}
-	tre := regexp.MustCompile(`tag:\s+([^,]+)`)
-	m := tre.FindAllStringSubmatch(string(b), -1)
-	if m == nil {
-		return UnknownVersion
-	}
-	for _, group := range m {
-		if len(group[1]) > 0 {
-			return strings.TrimSpace(group[1])
-		}
-	}
-	return UnknownVersion
+	return ReleaseVersion
 }
 
 // LongVersion the long form of the binary version.
 func LongVersion() string {
-	dirtyStr := ""
-	if (len(Dirty) > 0) && (Dirty != "false") {
-		dirtyStr = " (modified)"
+	if ReleaseVersion == "" || Hash == "" || CompileTime == "" {
+		return UnknownVersion
 	}
-	tagVersion := Version()
-	if tagVersion == UnknownVersion {
-		tagVersion = fmt.Sprintf("%s-dev.unknown", ReleaseVersion)
-	} else if tagVersion != ReleaseVersion {
-		tagVersion = fmt.Sprintf("dev release build .version=%s tag=%s", ReleaseVersion, tagVersion)
-	}
-	return fmt.Sprintf("%s compiled at %s from git hash %s%s", tagVersion, CompileTime, Hash, dirtyStr)
+
+	return fmt.Sprintf("Conduit %s (%s)", ReleaseVersion, ShortHash)
 }


### PR DESCRIPTION
## Summary

Enable goreleaser for building and publishing conduit binaries.

The automation triggers whenever a tag starting with `v1.` is pushed.

The previous versioning and deployment stuff seemed really complicated, and I'm really not sure what it was adding. Please let me know if this smaller process is missing any important functionality that needs to be added back.

## Test Plan

I pushed a tag to my fork:
* [The action ran.](https://github.com/winder/conduit/actions/runs/4432232042)
* [A release was published. ](https://github.com/winder/conduit/releases/tag/v1.0.0)

The downloaded binary looks good:
```
$ ./conduit -v
Conduit 1.0.0 (c8262a5)
```