### PR TITLE
build: Add deb and rpm artifacts.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,6 +28,17 @@ builds:
       -X github.com/algorand/conduit/version.CompileTime={{.Timestamp}}
       -X github.com/algorand/conduit/version.ReleaseVersion={{.Version}}
 
+nfpms:
+  - vendor: Algorand
+    homepage: https://algorand.com
+    maintainer: Algorand <dev@algorand.com>
+    description: framework for processing Algorand blockchain data
+    license: MIT
+    formats:
+      #- deb
+      #- rpm
+    file_name_template: "{{ .ConventionalFileName }}"
+
 archives:
   - replacements:
       darwin: Darwin


### PR DESCRIPTION
## Summary

Add goreleaser configuration to build debian and rpm artifacts. This is a basic configuration which builds deb/rpm packages for each of the configured architectures. With this configuration it only installs the command, there is no service file or systemd integration.

This PR adds the configuration, but the targets are all commented out.

Some questions that I'd like to understand before releasing any deb/rpm artifacts:
* Can a signing key be added to github for goreleaser to use?
* Should a service file be included?
* Do we maintain distribution servers?

## Test Plan

With deb/rpm enabled, the files seem to be the same size and contain the expected artifact:
```
~$ goreleaser release --skip-publish --snapshot --rm-dist
~$ dpkg -x dist/conduit_1.0.1\~next_arm64.deb folder
~$ tree folder/
folder/
└── usr
    └── bin
        └── conduit

~$ rpm2cpio dist/conduit-1.0.1\~next.x86_64.rpm|cpio -idmv
cpio: /usr/bin/conduit: Cannot open: Permission denied
/usr/bin/conduit
31273 blocks
```
