### PR TITLE
docker: Add docker to the release pipeline

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -18,14 +18,23 @@ jobs:
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
-      - uses: actions/setup-go@v3
+
+      - name: go dependency
+        uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
+
+      - name: Setup QEMU (docker multi-arch dependency)
+        uses: docker/setup-qemu-action@v2
+
+      - name: Setup Docker Buildx (docker multi-arch dependency)
+        uses: docker/setup-buildx-action@v2
+
       - uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
           version: latest
-          args: release --clean
+          args: release --clean --skip-docker
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,12 +29,44 @@ builds:
       -X github.com/algorand/conduit/version.ReleaseVersion={{.Version}}
 
 dockers:
-  -
-    skip_build: true
-    skip_push: true
+  - use: buildx
+    goos: linux
+    goarch: amd64
     image_templates:
-    - "algorand/conduit:latest"
-    - "algorand/conduit:{{ .Tag }}"
+    - "algorand/conduit:latest-amd64"
+    - "algorand/conduit:{{ .Version }}-amd64"
+    build_flag_templates:
+    - --platform=linux/amd64
+    - --label=org.opencontainers.image.title={{ .ProjectName }}
+    - --label=org.opencontainers.image.version={{ .Version }}
+    - --label=org.opencontainers.image.created={{ .Date }}
+    - --label=org.opencontainers.image.revision={{ .FullCommit }}
+    - --label=org.opencontainers.image.licenses=MIT
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+    - "algorand/conduit:latest-arm64"
+    - "algorand/conduit:{{ .Version }}-arm64"
+    build_flag_templates:
+    - --platform=linux/arm64
+    - --label=org.opencontainers.image.title={{ .ProjectName }}
+    - --label=org.opencontainers.image.version={{ .Version }}
+    - --label=org.opencontainers.image.created={{ .Date }}
+    - --label=org.opencontainers.image.revision={{ .FullCommit }}
+    - --label=org.opencontainers.image.licenses=MIT
+
+# automatically select amd64/arm64 when requesting "algorand/conduit"
+docker_manifests:
+  - name_template: "algorand/conduit:{{ .Version }}"
+    image_templates:
+    - "algorand/conduit:{{ .Version }}-amd64"
+    - "algorand/conduit:{{ .Version }}-arm64"
+  - name_template: "algorand/conduit:latest"
+    image_templates:
+    - "algorand/conduit:latest-amd64"
+    - "algorand/conduit:latest-arm64"
+
 archives:
   - replacements:
       darwin: Darwin

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,6 +28,13 @@ builds:
       -X github.com/algorand/conduit/version.CompileTime={{.Timestamp}}
       -X github.com/algorand/conduit/version.ReleaseVersion={{.Version}}
 
+dockers:
+  -
+    skip_build: true
+    skip_push: true
+    image_templates:
+    - "algorand/conduit:latest"
+    - "algorand/conduit:{{ .Tag }}"
 archives:
   - replacements:
       darwin: Darwin

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,7 +33,7 @@ dockers:
     goos: linux
     goarch: amd64
     image_templates:
-    - "algorand/conduit:latest-amd64"
+    - "algorand/conduit:latest{{ if .IsSnapshot }}-snapshot{{ end }}-amd64"
     - "algorand/conduit:{{ .Version }}-amd64"
     build_flag_templates:
     - --platform=linux/amd64
@@ -46,7 +46,7 @@ dockers:
     goos: linux
     goarch: arm64
     image_templates:
-    - "algorand/conduit:latest-arm64"
+    - "algorand/conduit:latest{{ if .IsSnapshot }}-snapshot{{ end }}-arm64"
     - "algorand/conduit:{{ .Version }}-arm64"
     build_flag_templates:
     - --platform=linux/arm64
@@ -62,10 +62,10 @@ docker_manifests:
     image_templates:
     - "algorand/conduit:{{ .Version }}-amd64"
     - "algorand/conduit:{{ .Version }}-arm64"
-  - name_template: "algorand/conduit:latest"
+  - name_template: "algorand/conduit:latest{{ if .IsSnapshot }}-snapshot{{ end }}"
     image_templates:
-    - "algorand/conduit:latest-amd64"
-    - "algorand/conduit:latest-arm64"
+    - "algorand/conduit:latest{{ if .IsSnapshot }}-snapshot{{ end }}-amd64"
+    - "algorand/conduit:latest{{ if .IsSnapshot }}-snapshot{{ end }}-arm64"
 
 archives:
   - replacements:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.17 as build
+
+# Download (and cache) dependencies
+COPY go.mod /conduit/
+COPY go.sum /conduit/
+RUN cd /conduit && \
+    go mod download
+
+# Add source and build
+ADD . /conduit
+RUN cd /conduit && \
+    make conduit
+
+# Final stage
+FROM debian:bullseye-slim
+
+COPY --from=build /conduit/cmd/conduit/conduit /conduit/conduit
+
+RUN useradd conduit
+RUN mkdir -p /conduit/data && \
+    chown -R conduit.conduit /conduit
+
+USER conduit
+WORKDIR /conduit
+ENTRYPOINT ["./conduit"]
+CMD ["-d", "data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,12 @@
-FROM golang:1.17 as build
-
-# Download (and cache) dependencies
-COPY go.mod /conduit/
-COPY go.sum /conduit/
-RUN cd /conduit && \
-    go mod download
-
-# Add source and build
-ADD . /conduit
-RUN cd /conduit && \
-    make conduit
-
-# Final stage
+# This dockerfile is used by goreleaser
 FROM debian:bullseye-slim
-
-COPY --from=build /conduit/cmd/conduit/conduit /conduit/conduit
 
 RUN useradd conduit
 RUN mkdir -p /conduit/data && \
     chown -R conduit.conduit /conduit
+
+# binary is passed into the build
+COPY conduit /conduit/conduit
 
 USER conduit
 WORKDIR /conduit

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -1,0 +1,49 @@
+**This container is a work in progress and not yet deployed to docker hub.**
+
+# Docker Image
+
+Algorand's Conduit data pipeline packaged for docker.
+
+This document provides some basic guidance and commands tailored
+for the docker container. For additional information refer to
+the [full documentation](https://developer.algorand.org/docs/get-details/conduit/GettingStarted/).
+
+# Usage
+
+Conduit needs a configuration file to define the data pipeline.
+There are built-in utilities to help create the configuration.
+Once a configuration is made launch conduit and pass in the configuration
+to use.
+
+## Creating a conduit.yml configuration
+
+The init subcommand can be used to create a configuration template.
+See the options here:
+```
+docker run algorand/conduit init -h
+```
+
+For a simple default configuration, run with no arguments:
+```
+docker run algorand/conduit init > conduit.yml
+```
+
+Plugins can also be named directly.
+
+See a list of available plugins:
+```
+docker run algorand/conduit list
+```
+
+Provide plugins to the init command:
+```
+docker run algorand/conduit init --importer algod --processors filter_processor --exporter postgresql > conduit.yml
+```
+
+## Run with conduit.yml
+
+With `conduit.yml` in your current working directory,
+launch the container:
+```
+docker run -it -v $(pwd)/conduit.yml:/conduit/data/conduit.yml algorand/conduit
+```


### PR DESCRIPTION
## Summary

Add a docker multi-arch build + deployment configuration.

~For now the docker hub deployment is disabled.~ **Hyperflow has added credentials to the repo so that the container can  be deployed.**

Goreleaser provides binaries from the build step to the Dockerfile to ensure containers have the same files as the archives.

## Test Plan

Tested with `goreleaser release --skip-publish --snapshot --clean`

The files are here:
```
~$ docker images|grep conduit
algorand/conduit   1.0.1-next-amd64   0863fc121046   About a minute ago   96.9MB
algorand/conduit   latest-amd64       0863fc121046   About a minute ago   96.9MB
algorand/conduit   1.0.1-next-arm64   907990ee4310   About a minute ago   90.5MB
algorand/conduit   latest-arm64       907990ee4310   About a minute ago   90.5MB
```

The architecture appears as expected:
```
~$ docker image inspect algorand/conduit:latest-arm64 | grep Architecture
        "Architecture": "arm64",
~$ docker image inspect algorand/conduit:latest-amd64 | grep Architecture
        "Architecture": "amd64",
```