### PR TITLE
algod importer: Fix archival mode and update tests.

### DIFF
--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -34,7 +34,7 @@ const (
 )
 
 const (
-	archivalMode = iota
+	archivalMode = iota + 1
 	followerMode
 )
 
@@ -63,11 +63,12 @@ var algodImporterMetadata = plugins.Metadata{
 }
 
 func (algodImp *algodImporter) OnComplete(input data.BlockData) error {
-	if algodImp.mode != followerMode {
-		return nil
+	if algodImp.mode == followerMode {
+		_, err := algodImp.aclient.SetSyncRound(input.Round() + 1).Do(algodImp.ctx)
+		return err
 	}
-	_, err := algodImp.aclient.SetSyncRound(input.Round() + 1).Do(algodImp.ctx)
-	return err
+
+	return nil
 }
 
 func (algodImp *algodImporter) Metadata() plugins.Metadata {
@@ -154,11 +155,14 @@ func (algodImp *algodImporter) monitorCatchpointCatchup() error {
 }
 
 func (algodImp *algodImporter) catchupNode(initProvider data.InitProvider) error {
-	// Set the sync round to the round provided by initProvider
-	_, err := algodImp.aclient.SetSyncRound(uint64(initProvider.NextDBRound())).Do(algodImp.ctx)
-	if err != nil {
-		return fmt.Errorf("received unexpected error setting sync round (%d): %w", initProvider.NextDBRound(), err)
+	if algodImp.mode == followerMode {
+		// Set the sync round to the round provided by initProvider
+		_, err := algodImp.aclient.SetSyncRound(uint64(initProvider.NextDBRound())).Do(algodImp.ctx)
+		if err != nil {
+			return fmt.Errorf("received unexpected error setting sync round (%d): %w", initProvider.NextDBRound(), err)
+		}
 	}
+
 	// Run Catchpoint Catchup
 	if algodImp.cfg.CatchupConfig.Catchpoint != "" {
 		cpRound, err := parseCatchpointRound(algodImp.cfg.CatchupConfig.Catchpoint)
@@ -187,7 +191,8 @@ func (algodImp *algodImporter) catchupNode(initProvider data.InitProvider) error
 			return err
 		}
 	}
-	_, err = algodImp.aclient.StatusAfterBlock(uint64(initProvider.NextDBRound())).Do(algodImp.ctx)
+
+	_, err := algodImp.aclient.StatusAfterBlock(uint64(initProvider.NextDBRound())).Do(algodImp.ctx)
 	if err != nil {
 		err = fmt.Errorf("received unexpected error (StatusAfterBlock) waiting for node to catchup: %w", err)
 	}


### PR DESCRIPTION
## Summary

When adding in the recent follow mode automation the algod import mode the archival configuration was not accounted for. A bug in the unit test which treated sync calls to be treated as no-ops instead of not found errors allowed the regression to be missed.

## Test Plan

Update archival mode unit tests to return a 404 when sync endpoints are called to properly reflect the behavior of an archival node.