### PR TITLE
docs: add missing repo directory.

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -42,7 +42,7 @@ jobs:
 
           # Copy the plugin docs using this ChatGPT special.
           # Set the directory to search
-          search_dir="conduit/plugins"
+          search_dir="conduit/conduit/plugins"
           target_base_dir=docs/docs/get-details/conduit/plugins
 
           # Loop through each README.md file found


### PR DESCRIPTION
## Summary

In https://github.com/algorand/conduit/pull/59 I forgot to include the repo directory, so the new plugin docs were not found.