### PR TITLE
algod importer: Auto catchpoint label lookup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,3 @@ Indexer was built in a way that strongly coupled it to Postgresql, and the defin
 Going forward we will continue to maintain the Indexer application, however our main focus will be enabling and optimizing a multitude of use cases through the Conduit pipeline design rather the singular Indexer pipeline.
 
 For a more detailed look at the differences between Conduit and Indexer, see [our migration guide](./docs/tutorials/IndexerMigration.md).
-
-# Known Issues
-
-## Restarting Follower Nodes Multiple Times in a Row
-
-When a follower node is restarted, the sync round is advanced to the node's ledger round. This causes a chain reaction where the node's ledger round is then advanced by `MaxAcctLookback` rounds. When this happens, the node should temporarily have access to 2 * `MaxAcctLookback` ledger state delta responses because some had been previously persisted to disk. However, if the follower node is restarted a second time before conduit has consumed the temporary ledger state delta objects, the node will become desynchronized from Conduit.
-
-When this happens the follower node must be manually re-synchronized with Conduit. This is done by launching a new follower node or running fast catchup to move to an earlier round.

--- a/conduit/plugins/importers/algod/README.md
+++ b/conduit/plugins/importers/algod/README.md
@@ -6,7 +6,9 @@ This plugin imports block data from an algod node. Fetch blocks data from the [a
 
 ### Automatic Fast Catchup
 
-If an admin API token and Auto (or a catchpoint label) are set, and a fast catchup would help, the plugin will coordinate running fast catchup on the node. If a catchpoint label is set, that takes precedent over auto being set to true.
+If an admin API token is set, the plugin will attempt to use a fast catchup when it would help reach the target round.
+A specific catchpoint can be provided, otherwise one will be selected automatically by querying the catchpoint URLs
+listed in the sample.
 
 ### Follower Node Orchestration
 
@@ -34,9 +36,11 @@ When using a follower node, ledger state delta objects are provided to the proce
 
     # Algod catchpoint catchup arguments
     catchup-config:
-        # Automatically download an appropriate catchpoint label. If false, you
-        # must specify a catchpoint to use fast catchup.
-        auto: false
+        # Algod Admin API Token. Set the admin token to use fast catchup during
+        # startup. The importer checks to see if a catchup would help and if so
+        # the catchpoint label will be used. If no catchpoint is provided, the
+        # importer will automatically select one.
+        admin-token: ""
         # The catchpoint to use when running fast catchup. If this is set it
         # overrides 'auto: true'. To select an appropriate catchpoint for your
         # deployment, see the list of available catchpoints for each network:
@@ -44,6 +48,4 @@ When using a follower node, ledger state delta objects are provided to the proce
         #   betanet: https://algorand-catchpoints.s3.us-east-2.amazonaws.com/consolidated/betanet_catchpoints.txt
         #   testnet: https://algorand-catchpoints.s3.us-east-2.amazonaws.com/consolidated/testnet_catchpoints.txt
         catchpoint: ""
-        # Algod Admin API Token
-        admin-token: ""
 ```

--- a/conduit/plugins/importers/algod/README.md
+++ b/conduit/plugins/importers/algod/README.md
@@ -6,7 +6,7 @@ This plugin imports block data from an algod node. Fetch blocks data from the [a
 
 ### Automatic Fast Catchup
 
-If an admin API token and Auto (or a catchpoint label) are set, the plugin will automatically run fast catchup on startup if the node is behind the current pipeline round.
+If an admin API token and Auto (or a catchpoint label) are set, the plugin will automatically run fast catchup on startup if the node is behind the current pipeline round. If a catchpoint label is set, that takes precedent over auto being set to true.
 
 ### Follower Node Orchestration
 

--- a/conduit/plugins/importers/algod/README.md
+++ b/conduit/plugins/importers/algod/README.md
@@ -6,7 +6,7 @@ This plugin imports block data from an algod node. Fetch blocks data from the [a
 
 ### Automatic Fast Catchup
 
-If an admin API token and Auto (or a catchpoint label) are set, the plugin will automatically run fast catchup on startup if the node is behind the current pipeline round. If a catchpoint label is set, that takes precedent over auto being set to true.
+If an admin API token and Auto (or a catchpoint label) are set, and a fast catchup would help, the plugin will coordinate running fast catchup on the node. If a catchpoint label is set, that takes precedent over auto being set to true.
 
 ### Follower Node Orchestration
 

--- a/conduit/plugins/importers/algod/README.md
+++ b/conduit/plugins/importers/algod/README.md
@@ -6,7 +6,7 @@ This plugin imports block data from an algod node. Fetch blocks data from the [a
 
 ### Automatic Fast Catchup
 
-If an admin API token and catchpoint are set, the plugin will automatically run fast catchup on startup if the node is behind the current pipeline round.
+If an admin API token and Auto (or a catchpoint label) are set, the plugin will automatically run fast catchup on startup if the node is behind the current pipeline round.
 
 ### Follower Node Orchestration
 
@@ -34,11 +34,15 @@ When using a follower node, ledger state delta objects are provided to the proce
 
     # Algod catchpoint catchup arguments
     catchup-config:
-        # The catchpoint to use when running fast catchup. Select an appropriate catchpoint for your deployment.
-        # They are published in the following locations:
-        # mainnet: https://algorand-catchpoints.s3.us-east-2.amazonaws.com/consolidated/mainnet_catchpoints.txt
-        # betanet: https://algorand-catchpoints.s3.us-east-2.amazonaws.com/consolidated/betanet_catchpoints.txt
-        # testnet: https://algorand-catchpoints.s3.us-east-2.amazonaws.com/consolidated/testnet_catchpoints.txt
+        # Automatically download an appropriate catchpoint label. If false, you
+        # must specify a catchpoint to use fast catchup.
+        auto: false
+        # The catchpoint to use when running fast catchup. If this is set it
+        # overrides 'auto: true'. To select an appropriate catchpoint for your
+        # deployment, see the list of available catchpoints for each network:
+        #   mainnet: https://algorand-catchpoints.s3.us-east-2.amazonaws.com/consolidated/mainnet_catchpoints.txt
+        #   betanet: https://algorand-catchpoints.s3.us-east-2.amazonaws.com/consolidated/betanet_catchpoints.txt
+        #   testnet: https://algorand-catchpoints.s3.us-east-2.amazonaws.com/consolidated/testnet_catchpoints.txt
         catchpoint: ""
         # Algod Admin API Token
         admin-token: ""

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -226,11 +226,12 @@ func (algodImp *algodImporter) catchupNode(catchpoint string, nextRound uint64) 
 			if err != nil {
 				return err
 			}
-		}
-		// Wait for algod to catchup
-		err = algodImp.monitorCatchpointCatchup()
-		if err != nil {
-			return err
+
+			// Wait for algod to catchup
+			err = algodImp.monitorCatchpointCatchup()
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -183,7 +183,8 @@ func getMissingCatchpointLabel(URL string, nextRound uint64) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		if uint64(round) > nextRound {
+		// TODO: Change >= to > after go-algorand#5352 is fixed.
+		if uint64(round) >= nextRound {
 			break
 		}
 		label = line
@@ -200,7 +201,8 @@ func getMissingCatchpointLabel(URL string, nextRound uint64) (string, error) {
 // is detected.
 func checkRounds(logger *logrus.Logger, catchpointRound, nodeRound, targetRound uint64) (bool, error) {
 	// Make sure catchpoint round is not in the future
-	canCatchup := catchpointRound <= targetRound
+	// TODO: Change < to <= after go-algorand#5352 is fixed.
+	canCatchup := catchpointRound < targetRound
 	mustCatchup := targetRound < nodeRound
 	shouldCatchup := nodeRound < catchpointRound
 

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -204,23 +204,25 @@ func checkRounds(logger *logrus.Logger, catchpointRound, nodeRound, targetRound 
 	mustCatchup := targetRound < nodeRound
 	shouldCatchup := nodeRound < catchpointRound
 
+	msg := fmt.Sprintf("Node round %d, target round %d, catchpoint round %d", nodeRound, targetRound, catchpointRound)
+
 	if canCatchup && mustCatchup {
-		logger.Infof("Catchup required. Node round %d is ahead of target round %d", nodeRound, targetRound)
+		logger.Infof("Catchup required, node round ahead of target round. %s.", msg)
 		return true, nil
 	}
 
 	if canCatchup && shouldCatchup {
-		logger.Infof("Catchup required. Node round %d and target round %d are behind catchpoint round %d", nodeRound, targetRound, catchpointRound)
+		logger.Infof("Catchup requested. %s.", msg)
 		return true, nil
 	}
 
 	if !canCatchup && mustCatchup {
-		err := fmt.Errorf("node round %d is ahead of target round %d", nodeRound, targetRound)
-		logger.Errorf("Catchup required but no valid catchpoint available: %s.", err.Error())
+		err := fmt.Errorf("node round %d and catchpoint round %d are ahead of target round %d", nodeRound, catchpointRound, targetRound)
+		logger.Errorf("Catchup required but no valid catchpoint available, %s.", err.Error())
 		return false, err
 	}
 
-	logger.Infof("No catchup required. Node round %d, target round %d, catchpoint round %d.", nodeRound, targetRound, catchpointRound)
+	logger.Infof("No catchup required. %s.", msg)
 	return false, nil
 }
 

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -308,9 +308,7 @@ func (algodImp *algodImporter) Init(ctx context.Context, initProvider data.InitP
 		}
 	}
 
-	if catchpoint != "" {
-		err = algodImp.catchupNode(catchpoint, uint64(initProvider.NextDBRound()))
-	}
+	err = algodImp.catchupNode(catchpoint, uint64(initProvider.NextDBRound()))
 
 	return &genesis, err
 }

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -211,7 +211,7 @@ func checkRounds(logger *logrus.Logger, catchpointRound, nodeRound, targetRound 
 
 	if canCatchup && shouldCatchup {
 		logger.Infof("Catchup required. Node round %d and target round %d are behind catchpoint round %d", nodeRound, targetRound, catchpointRound)
-
+		return true, nil
 	}
 
 	if !canCatchup && mustCatchup {
@@ -220,7 +220,7 @@ func checkRounds(logger *logrus.Logger, catchpointRound, nodeRound, targetRound 
 		return false, err
 	}
 
-	logger.Infof("No catchup required. Node round %d is behind target round %d.", nodeRound, targetRound)
+	logger.Infof("No catchup required. Node round %d, target round %d, catchpoint round %d.", nodeRound, targetRound, catchpointRound)
 	return false, nil
 }
 

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -228,7 +228,6 @@ func checkRounds(logger *logrus.Logger, catchpointRound, nodeRound, targetRound 
 
 func (algodImp *algodImporter) catchupNode(catchpoint string, targetRound uint64) error {
 	if catchpoint != "" {
-		algodImp.logger.Infof("Starting catchpoint catchup with label %s", catchpoint)
 		cpRound, err := parseCatchpointRound(catchpoint)
 		if err != nil {
 			return err
@@ -241,6 +240,8 @@ func (algodImp *algodImporter) catchupNode(catchpoint string, targetRound uint64
 		if runCatchup, err := checkRounds(algodImp.logger, uint64(cpRound), nStatus.LastRound, targetRound); !runCatchup || err != nil {
 			return err
 		} else {
+			algodImp.logger.Infof("Starting catchpoint catchup with label %s", catchpoint)
+
 			err = algodImp.startCatchpointCatchup(catchpoint)
 			if err != nil {
 				return err

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -257,7 +257,8 @@ func (algodImp *algodImporter) catchupNode(catchpoint string, targetRound uint64
 		}
 	}
 
-	// It is possible for the round to go backwards after a catchup. So sync must be called after fast catchup.
+	// Set the sync round after fast-catchup in case the node round is ahead of the target round.
+	// Trying to set it before would cause an error.
 	if algodImp.mode == followerMode {
 		// Set the sync round to the round provided by initProvider
 		_, err := algodImp.aclient.SetSyncRound(targetRound).Do(algodImp.ctx)

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -177,7 +177,7 @@ func getMissingCatchpointLabel(URL string, nextRound uint64) (string, error) {
 	var label string
 	labels := string(body)
 	scanner := bufio.NewScanner(strings.NewReader(labels))
-	for scanner.Scan() {
+	for scanner.Scan() && scanner.Text() != "" {
 		line := scanner.Text()
 		round, err := parseCatchpointRound(line)
 		if err != nil {
@@ -189,11 +189,10 @@ func getMissingCatchpointLabel(URL string, nextRound uint64) (string, error) {
 		label = line
 	}
 
-	// check if label is a valid catchpoint label
-	_, err = parseCatchpointRound(label)
-	if err != nil {
-		return "", fmt.Errorf("invalid catchpoint label: %s", label)
+	if label == "" {
+		return "", fmt.Errorf("no catchpoint label found for round %d at: %s", nextRound, URL)
 	}
+
 	return label, nil
 }
 

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -330,14 +330,16 @@ func (algodImp *algodImporter) Init(ctx context.Context, initProvider data.InitP
 
 	catchpoint := ""
 
-	// check for catchpoint to use.
-	if algodImp.cfg.CatchupConfig.Catchpoint != "" {
-		catchpoint = algodImp.cfg.CatchupConfig.Catchpoint
-	} else if algodImp.cfg.CatchupConfig.Auto {
-		URL := fmt.Sprintf(catchpointsURL, genesis.Network)
-		catchpoint, err = getMissingCatchpointLabel(URL, uint64(initProvider.NextDBRound()))
-		if err != nil {
-			return nil, fmt.Errorf("unable to lookup catchpoint: %w", err)
+	// If there is an admin token, look for a catchpoint to use.
+	if algodImp.cfg.CatchupConfig.AdminToken != "" {
+		if algodImp.cfg.CatchupConfig.Catchpoint != "" {
+			catchpoint = algodImp.cfg.CatchupConfig.Catchpoint
+		} else {
+			URL := fmt.Sprintf(catchpointsURL, genesis.Network)
+			catchpoint, err = getMissingCatchpointLabel(URL, uint64(initProvider.NextDBRound()))
+			if err != nil {
+				return nil, fmt.Errorf("unable to lookup catchpoint: %w", err)
+			}
 		}
 	}
 

--- a/conduit/plugins/importers/algod/algod_importer_config.go
+++ b/conduit/plugins/importers/algod/algod_importer_config.go
@@ -19,8 +19,6 @@ type Config struct {
 
 // CatchupParams provides information required to sync a follower node to the pipeline round
 type CatchupParams struct {
-	// <code>auto</code> controls whether to automatically download an appropriate catchpoint label.
-	Auto bool `yaml:"auto"`
 	// <code>catchpoint</code> is the catchpoint used to run fast catchup on startup when your node is behind the current pipeline round.
 	Catchpoint string `yaml:"catchpoint"`
 	// <code>admin-token</code> is the algod admin API token.

--- a/conduit/plugins/importers/algod/algod_importer_config.go
+++ b/conduit/plugins/importers/algod/algod_importer_config.go
@@ -19,6 +19,8 @@ type Config struct {
 
 // CatchupParams provides information required to sync a follower node to the pipeline round
 type CatchupParams struct {
+	// <code>auto</code> controls whether to automatically download an appropriate catchpoint label.
+	Auto bool `yaml:"auto"`
 	// <code>catchpoint</code> is the catchpoint used to run fast catchup on startup when your node is behind the current pipeline round.
 	Catchpoint string `yaml:"catchpoint"`
 	// <code>admin-token</code> is the algod admin API token.

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -126,12 +126,12 @@ func Test_checkRounds(t *testing.T) {
 			args: args{
 				catchpointRound: 1002,
 				nodeRound:       1001,
-				targetRound:     1002,
+				targetRound:     1003,
 			},
 			want:         true,
 			wantErr:      assert.NoError,
 			wantLogLevel: logrus.InfoLevel,
-			wantLogMsg:   "Catchup requested. Node round 1001, target round 1002, catchpoint round 1002.",
+			wantLogMsg:   "Catchup requested. Node round 1001, target round 1003, catchpoint round 1002.",
 		},
 		{
 			name: "Catchup required. Success.",

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -551,7 +551,7 @@ func TestGetBlockErrors(t *testing.T) {
 	}
 }
 
-func TestMissingCatchpointLabel(t *testing.T) {
+func TestGetMissingCatchpointLabel(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "1000#abcd\n1100#abcd\n1200#abcd")
 	}))
@@ -560,4 +560,13 @@ func TestMissingCatchpointLabel(t *testing.T) {
 	require.NoError(t, err)
 	// closest without going over
 	require.Equal(t, "1100#abcd", label)
+}
+
+func TestGetMissingCatchpointLabelError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "")
+	}))
+	defer ts.Close()
+	_, err := getMissingCatchpointLabel(ts.URL, 1100)
+	require.ErrorContains(t, err, "no catchpoint label found for round 1100 at:")
 }

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -649,7 +649,7 @@ func TestGetMissingCatchpointLabel(t *testing.T) {
 		fmt.Fprintln(w, "1000#abcd\n1100#abcd\n1200#abcd")
 	}))
 	defer ts.Close()
-	label, err := getMissingCatchpointLabel(ts.URL, 1100)
+	label, err := getMissingCatchpointLabel(ts.URL, 1101)
 	require.NoError(t, err)
 	// closest without going over
 	require.Equal(t, "1100#abcd", label)

--- a/conduit/plugins/importers/algod/mock_algod_test.go
+++ b/conduit/plugins/importers/algod/mock_algod_test.go
@@ -70,6 +70,7 @@ func MakeGenesisResponder(genesis types.Genesis) func(reqPath string, w http.Res
 // GenesisResponder handles /v2/genesis requests and returns an empty Genesis object
 var GenesisResponder = MakeGenesisResponder(types.Genesis{
 	Comment: "",
+	Network: "FAKE",
 	DevMode: true,
 })
 

--- a/conduit/plugins/importers/algod/sample.yaml
+++ b/conduit/plugins/importers/algod/sample.yaml
@@ -16,11 +16,15 @@
 
     # Algod catchpoint catchup arguments
     catchup-config:
-        # The catchpoint to use when running fast catchup. Select an appropriate catchpoint for your deployment.
-        # They are published in the following locations:
-        # mainnet: https://algorand-catchpoints.s3.us-east-2.amazonaws.com/consolidated/mainnet_catchpoints.txt
-        # betanet: https://algorand-catchpoints.s3.us-east-2.amazonaws.com/consolidated/betanet_catchpoints.txt
-        # testnet: https://algorand-catchpoints.s3.us-east-2.amazonaws.com/consolidated/testnet_catchpoints.txt
+        # Automatically download an appropriate catchpoint label. If false, you
+        # must specify a catchpoint to use fast catchup.
+        auto: false
+        # The catchpoint to use when running fast catchup. If this is set it
+        # overrides 'auto: true'. To select an appropriate catchpoint for your
+        # deployment, see the list of available catchpoints for each network:
+        #   mainnet: https://algorand-catchpoints.s3.us-east-2.amazonaws.com/consolidated/mainnet_catchpoints.txt
+        #   betanet: https://algorand-catchpoints.s3.us-east-2.amazonaws.com/consolidated/betanet_catchpoints.txt
+        #   testnet: https://algorand-catchpoints.s3.us-east-2.amazonaws.com/consolidated/testnet_catchpoints.txt
         catchpoint: ""
         # Algod Admin API Token
         admin-token: ""

--- a/conduit/plugins/importers/algod/sample.yaml
+++ b/conduit/plugins/importers/algod/sample.yaml
@@ -16,9 +16,11 @@
 
     # Algod catchpoint catchup arguments
     catchup-config:
-        # Automatically download an appropriate catchpoint label. If false, you
-        # must specify a catchpoint to use fast catchup.
-        auto: false
+        # Algod Admin API Token. Set the admin token to use fast catchup during
+        # startup. The importer checks to see if a catchup would help and if so
+        # the catchpoint label will be used. If no catchpoint is provided, the
+        # importer will automatically select one.
+        admin-token: ""
         # The catchpoint to use when running fast catchup. If this is set it
         # overrides 'auto: true'. To select an appropriate catchpoint for your
         # deployment, see the list of available catchpoints for each network:
@@ -26,5 +28,3 @@
         #   betanet: https://algorand-catchpoints.s3.us-east-2.amazonaws.com/consolidated/betanet_catchpoints.txt
         #   testnet: https://algorand-catchpoints.s3.us-east-2.amazonaws.com/consolidated/testnet_catchpoints.txt
         catchpoint: ""
-        # Algod Admin API Token
-        admin-token: ""

--- a/docs/tutorials/IndexerWriter.md
+++ b/docs/tutorials/IndexerWriter.md
@@ -118,10 +118,10 @@ Configuration:
 * `importer.config.token`: the contents of `algod_data/algod.token`
 * `exporter.config.connection-string`: `host=localhost port=5555 user=algorand password=pgpass dbname=conduit`
 
-If you are connecting to an existing PostgreSQL database, you can also set a
-catchpoint and the admin token and enable `auto` catchup.  You can optionally
+If you are connecting to an existing PostgreSQL database, you can also set
+the admin token and enable `auto`.  You can optionally
 specify the catchup label directly. If those are configured, Conduit will
-automatically initialize the node using fast catchup.
+coordinate initializing the node by using fast catchup.
 
 Review the inline documentation in `conduit.yml` and decide if there are any
 other settings you would like to update.

--- a/docs/tutorials/IndexerWriter.md
+++ b/docs/tutorials/IndexerWriter.md
@@ -119,8 +119,9 @@ Configuration:
 * `exporter.config.connection-string`: `host=localhost port=5555 user=algorand password=pgpass dbname=conduit`
 
 If you are connecting to an existing PostgreSQL database, you can also set a
-catchpoint and the admin token. If those are set Conduit will automatically
-initialize the node using fast catchup.
+catchpoint and the admin token and enable `auto` catchup.  You can optionally
+specify the catchup label directly. If those are configured, Conduit will
+automatically initialize the node using fast catchup.
 
 Review the inline documentation in `conduit.yml` and decide if there are any
 other settings you would like to update.


### PR DESCRIPTION
## Summary

Adds a new option to automatically lookup an appropriate catchpoint label during startup.

## Test Plan

New unit tests.

Manually run conduit with `-r 27000001` to see that the correct catchpoint label is automatically populated.