### PR TITLE
algod importer: check if node needs catchup.

### DIFF
--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -251,10 +251,11 @@ func (algodImp *algodImporter) needsCatchup(targetRound uint64) bool {
 // node to slow catchup.
 func (algodImp *algodImporter) catchupNode(network string, targetRound uint64) error {
 	if !algodImp.needsCatchup(targetRound) {
+		algodImp.logger.Infof("No catchup required to reach round %d", targetRound)
 		return nil
 	}
 
-	algodImp.log.Infof("Catchup required to reach round %d", targetRound)
+	algodImp.logger.Infof("Catchup required to reach round %d", targetRound)
 
 	catchpoint := ""
 

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -230,7 +230,7 @@ func checkRounds(logger *logrus.Logger, catchpointRound, nodeRound, targetRound 
 
 func (algodImp *algodImporter) needsCatchup(targetRound uint64) bool {
 	if algodImp.mode == followerMode {
-		// If we are in follower mode, use the sync round as a proxy for the node round
+		// If we are in follower mode, check if the round delta is available.
 		_, err := algodImp.getDelta(targetRound)
 		return err != nil
 	} else {

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -236,15 +236,15 @@ func (algodImp *algodImporter) needsCatchup(targetRound uint64) bool {
 			algodImp.logger.Infof("Unable to fetch state delta for round %d: %s", targetRound, err)
 		}
 		return err != nil
-	} else {
-		// Otherwise just check if the block is available.
-		_, err := algodImp.aclient.Block(targetRound).Do(algodImp.ctx)
-		if err != nil {
-			algodImp.logger.Infof("Unable to fetch block for round %d: %s", targetRound, err)
-		}
-		// If the block is not available, we must catchup.
-		return err != nil
 	}
+
+	// Otherwise just check if the block is available.
+	_, err := algodImp.aclient.Block(targetRound).Do(algodImp.ctx)
+	if err != nil {
+		algodImp.logger.Infof("Unable to fetch block for round %d: %s", targetRound, err)
+	}
+	// If the block is not available, we must catchup.
+	return err != nil
 }
 
 // catchupNode facilitates catching up via fast catchup, or waiting for the
@@ -253,6 +253,8 @@ func (algodImp *algodImporter) catchupNode(network string, targetRound uint64) e
 	if !algodImp.needsCatchup(targetRound) {
 		return nil
 	}
+
+	algodImp.log.Infof("Catchup required to reach round %d", targetRound)
 
 	catchpoint := ""
 

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -27,6 +27,7 @@ func New() *algodImporter {
 }
 
 func TestImporterMetadata(t *testing.T) {
+	t.Parallel()
 	testImporter := New()
 	metadata := testImporter.Metadata()
 	assert.Equal(t, metadata.Name, algodImporterMetadata.Name)
@@ -35,6 +36,7 @@ func TestImporterMetadata(t *testing.T) {
 }
 
 func TestCloseSuccess(t *testing.T) {
+	t.Parallel()
 	logger := logrus.New()
 	ctx := context.Background()
 	pRound := sdk.Round(1)
@@ -116,6 +118,7 @@ func Test_checkRounds(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			testLogger, hook := test.NewNullLogger()
 			got, err := checkRounds(testLogger, tt.args.catchpointRound, tt.args.nodeRound, tt.args.targetRound)
 
@@ -298,6 +301,7 @@ func TestInitCatchup(t *testing.T) {
 }
 
 func TestInitParseUrlFailure(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	pRound := sdk.Round(1)
 	logger := logrus.New()
@@ -313,6 +317,7 @@ netaddr: %s
 }
 
 func TestInitModeFailure(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	pRound := sdk.Round(1)
 	logger := logrus.New()
@@ -329,6 +334,7 @@ netaddr: %s
 }
 
 func TestInitGenesisFailure(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	pRound := sdk.Round(1)
 	logger := logrus.New()
@@ -346,6 +352,7 @@ netaddr: %s
 }
 
 func TestInitUnmarshalFailure(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	pRound := sdk.Round(1)
 	logger := logrus.New()
@@ -358,6 +365,7 @@ func TestInitUnmarshalFailure(t *testing.T) {
 }
 
 func TestConfigDefault(t *testing.T) {
+	t.Parallel()
 	testImporter := New()
 	expected, err := yaml.Marshal(&Config{})
 	if err != nil {
@@ -367,6 +375,7 @@ func TestConfigDefault(t *testing.T) {
 }
 
 func TestWaitForBlockBlockFailure(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	pRound := sdk.Round(1)
 	logger := logrus.New()
@@ -547,6 +556,7 @@ netaddr: %s
 }
 
 func TestAlgodImporter_ProvideMetrics(t *testing.T) {
+	t.Parallel()
 	testImporter := &algodImporter{}
 	assert.Len(t, testImporter.ProvideMetrics("blah"), 1)
 }
@@ -654,6 +664,7 @@ func TestGetBlockErrors(t *testing.T) {
 }
 
 func TestGetMissingCatchpointLabel(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "1000#abcd\n1100#abcd\n1200#abcd")
 	}))
@@ -665,6 +676,7 @@ func TestGetMissingCatchpointLabel(t *testing.T) {
 }
 
 func TestGetMissingCatchpointLabelError(t *testing.T) {
+	t.Parallel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "")
 	}))

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -213,8 +213,9 @@ func TestInitCatchup(t *testing.T) {
 			algodServer: NewAlgodServer(
 				GenesisResponder,
 				MakePostSyncRoundResponder(http.StatusOK),
+				// OK in 'catchupNode', fail in 'monitorCatchup'
 				MakeJsonResponderSeries("/v2/status", []int{http.StatusOK, http.StatusBadRequest}, []interface{}{models.NodeStatus{LastRound: 1235}}),
-				MakeMsgpStatusResponder("get", "/v2/catchup/", http.StatusOK, "")),
+				MakeMsgpStatusResponder("post", "/v2/catchup/", http.StatusOK, "")),
 			err:  "received unexpected error getting node status: HTTP 400",
 			logs: []string{},
 		}, {
@@ -234,7 +235,7 @@ func TestInitCatchup(t *testing.T) {
 				GenesisResponder,
 				MakePostSyncRoundResponder(http.StatusOK),
 				MakeJsonResponderSeries("/v2/status", []int{http.StatusOK, http.StatusOK, http.StatusBadRequest}, []interface{}{models.NodeStatus{LastRound: 1235}}),
-				MakeMsgpStatusResponder("post", "/v2/catchup/", http.StatusOK, "")),
+				MakeMsgpStatusResponder("post", "/v2/catchup/", http.StatusOK, nil)),
 			err:  "received unexpected error (StatusAfterBlock) waiting for node to catchup: HTTP 400",
 			logs: []string{},
 		},

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -66,7 +66,7 @@ netaddr: %s
 func TestInitSuccess(t *testing.T) {
 	tests := []struct {
 		name      string
-		responder func(string, http.ResponseWriter) bool
+		responder algodCustomHandler
 	}{
 		{
 			name:      "archival",
@@ -533,9 +533,9 @@ func TestGetBlockErrors(t *testing.T) {
 	testcases := []struct {
 		name                string
 		rnd                 uint64
-		blockAfterResponder func(string, http.ResponseWriter) bool
-		blockResponder      func(string, http.ResponseWriter) bool
-		deltaResponder      func(string, http.ResponseWriter) bool
+		blockAfterResponder algodCustomHandler
+		blockResponder      algodCustomHandler
+		deltaResponder      algodCustomHandler
 		logs                []string
 		err                 string
 	}{

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -238,7 +238,29 @@ func TestInitCatchup(t *testing.T) {
 				MakeMsgpStatusResponder("post", "/v2/catchup/", http.StatusOK, nil)),
 			err:  "received unexpected error (StatusAfterBlock) waiting for node to catchup: HTTP 400",
 			logs: []string{},
-		},
+		}, {
+			name:        "monitor catchup success",
+			adminToken:  "admin",
+			targetRound: 1237,
+			catchpoint:  "1236#abcd",
+			algodServer: NewAlgodServer(
+				GenesisResponder,
+				MakePostSyncRoundResponder(http.StatusOK),
+				MakeJsonResponderSeries("/v2/status", []int{http.StatusOK}, []interface{}{
+					models.NodeStatus{LastRound: 1235},
+					models.NodeStatus{Catchpoint: "1236#abcd", CatchpointProcessedAccounts: 1, CatchpointTotalAccounts: 1},
+					models.NodeStatus{Catchpoint: "1236#abcd", CatchpointVerifiedAccounts: 1, CatchpointTotalAccounts: 1},
+					models.NodeStatus{Catchpoint: "1236#abcd", CatchpointAcquiredBlocks: 1, CatchpointTotalBlocks: 1},
+					models.NodeStatus{Catchpoint: "1236#abcd"},
+					models.NodeStatus{LastRound: 1236},
+				}),
+				MakeMsgpStatusResponder("post", "/v2/catchup/", http.StatusOK, "")),
+			logs: []string{
+				"catchup phase Processed Accounts: 1 / 1",
+				"catchup phase Verified Accounts: 1 / 1",
+				"catchup phase Acquired Blocks: 1 / 1",
+				"catchup phase Verified Blocks",
+			}},
 	}
 	for _, ttest := range tests {
 		ttest := ttest


### PR DESCRIPTION
## Summary

The catchup logic was too aggressive. It should not run unless it's needed. With this change the target block / state delta are queried. If they are available the catchup phase is skipped.

## Test Plan

Update unit tests.