### PR TITLE
bugfix: indexer import types

### DIFF
--- a/conduit/plugins/processors/filterprocessor/gen/generate.go
+++ b/conduit/plugins/processors/filterprocessor/gen/generate.go
@@ -50,7 +50,7 @@ var ignoreTags = map[string]bool{
 	// TODO: support map types?
 	"dt.gd": true,
 	"dt.ld": true,
-	// TODO: support array types?
+	// TODO: support slice/array types?
 	"txn.apaa": true,
 	"txn.apat": true,
 	"txn.apfa": true,

--- a/conduit/plugins/processors/filterprocessor/gen/generate.go
+++ b/conduit/plugins/processors/filterprocessor/gen/generate.go
@@ -50,7 +50,6 @@ var ignoreTags = map[string]bool{
 	// TODO: support map types?
 	"dt.gd": true,
 	"dt.ld": true,
-	"dt.sa": true,
 	// TODO: support array types?
 	"txn.apaa": true,
 	"txn.apat": true,
@@ -60,6 +59,7 @@ var ignoreTags = map[string]bool{
 	"txn.apap": true,
 	"txn.apsu": true,
 	"dt.lg":    true,
+	"dt.sa":    true,
 }
 
 func noCast(t reflect.StructField) bool {

--- a/conduit/plugins/processors/filterprocessor/gen/generate.go
+++ b/conduit/plugins/processors/filterprocessor/gen/generate.go
@@ -50,6 +50,7 @@ var ignoreTags = map[string]bool{
 	// TODO: support map types?
 	"dt.gd": true,
 	"dt.ld": true,
+	"dt.sa": true,
 	// TODO: support array types?
 	"txn.apaa": true,
 	"txn.apat": true,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/algorand/conduit
 go 1.17
 
 require (
-	github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230511222239-d0007f96cf95
+	github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230515174312-963d360c9eb7
 	github.com/algorand/go-codec/codec v1.1.8
 	github.com/algorand/indexer v0.0.0-20230315150109-cf0074cfd4ed
 	github.com/jackc/pgx/v4 v4.13.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/algorand/conduit
 go 1.17
 
 require (
-	github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230324200319-055c8d2b174a
+	github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230511222239-d0007f96cf95
 	github.com/algorand/go-codec/codec v1.1.8
 	github.com/algorand/indexer v0.0.0-20230315150109-cf0074cfd4ed
 	github.com/jackc/pgx/v4 v4.13.0

--- a/go.sum
+++ b/go.sum
@@ -87,6 +87,8 @@ github.com/algorand/avm-abi v0.2.0/go.mod h1:+CgwM46dithy850bpTeHh9MC99zpn2Snirb
 github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230228201805-5b8c99b1412c/go.mod h1:Nt3EHpP8AznLs0/EFfhr0/xsVf5ucnvjNeRygGgbUzM=
 github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230324200319-055c8d2b174a h1:fv15GJlyepaaP517PeiJuPX0Q1Wmr17T8uZzevep/TU=
 github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230324200319-055c8d2b174a/go.mod h1:Nt3EHpP8AznLs0/EFfhr0/xsVf5ucnvjNeRygGgbUzM=
+github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230511222239-d0007f96cf95 h1:gDG3LLwZqVUBJdVy0m2rmc/+30qpkghkEU/sYn88FUE=
+github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230511222239-d0007f96cf95/go.mod h1:Nt3EHpP8AznLs0/EFfhr0/xsVf5ucnvjNeRygGgbUzM=
 github.com/algorand/go-codec v1.1.8 h1:XDSreeeZY8gMst6Edz4RBkl08/DGMJOeHYkoXL2B7wI=
 github.com/algorand/go-codec v1.1.8/go.mod h1:XhzVs6VVyWMLu6cApb9/192gBjGRVGm5cX5j203Heg4=
 github.com/algorand/go-codec/codec v1.1.8 h1:lsFuhcOH2LiEhpBH3BVUUkdevVmwCRyvb7FCAAPeY6U=

--- a/go.sum
+++ b/go.sum
@@ -85,10 +85,6 @@ github.com/algorand/avm-abi v0.1.1/go.mod h1:+CgwM46dithy850bpTeHh9MC99zpn2Snirb
 github.com/algorand/avm-abi v0.2.0 h1:bkjsG+BOEcxUcnGSALLosmltE0JZdg+ZisXKx0UDX2k=
 github.com/algorand/avm-abi v0.2.0/go.mod h1:+CgwM46dithy850bpTeHh9MC99zpn2Snirb3QTl2O/g=
 github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230228201805-5b8c99b1412c/go.mod h1:Nt3EHpP8AznLs0/EFfhr0/xsVf5ucnvjNeRygGgbUzM=
-github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230324200319-055c8d2b174a h1:fv15GJlyepaaP517PeiJuPX0Q1Wmr17T8uZzevep/TU=
-github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230324200319-055c8d2b174a/go.mod h1:Nt3EHpP8AznLs0/EFfhr0/xsVf5ucnvjNeRygGgbUzM=
-github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230511222239-d0007f96cf95 h1:gDG3LLwZqVUBJdVy0m2rmc/+30qpkghkEU/sYn88FUE=
-github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230511222239-d0007f96cf95/go.mod h1:Nt3EHpP8AznLs0/EFfhr0/xsVf5ucnvjNeRygGgbUzM=
 github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230515174312-963d360c9eb7 h1:72UIyiVVT1H2J6VtYW/iFP5rKEYRe0zivIR35g6M2k0=
 github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230515174312-963d360c9eb7/go.mod h1:Nt3EHpP8AznLs0/EFfhr0/xsVf5ucnvjNeRygGgbUzM=
 github.com/algorand/go-codec v1.1.8 h1:XDSreeeZY8gMst6Edz4RBkl08/DGMJOeHYkoXL2B7wI=

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230324200319-055c8d2b174a h1:fv1
 github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230324200319-055c8d2b174a/go.mod h1:Nt3EHpP8AznLs0/EFfhr0/xsVf5ucnvjNeRygGgbUzM=
 github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230511222239-d0007f96cf95 h1:gDG3LLwZqVUBJdVy0m2rmc/+30qpkghkEU/sYn88FUE=
 github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230511222239-d0007f96cf95/go.mod h1:Nt3EHpP8AznLs0/EFfhr0/xsVf5ucnvjNeRygGgbUzM=
+github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230515174312-963d360c9eb7 h1:72UIyiVVT1H2J6VtYW/iFP5rKEYRe0zivIR35g6M2k0=
+github.com/algorand/go-algorand-sdk/v2 v2.0.0-20230515174312-963d360c9eb7/go.mod h1:Nt3EHpP8AznLs0/EFfhr0/xsVf5ucnvjNeRygGgbUzM=
 github.com/algorand/go-codec v1.1.8 h1:XDSreeeZY8gMst6Edz4RBkl08/DGMJOeHYkoXL2B7wI=
 github.com/algorand/go-codec v1.1.8/go.mod h1:XhzVs6VVyWMLu6cApb9/192gBjGRVGm5cX5j203Heg4=
 github.com/algorand/go-codec/codec v1.1.8 h1:lsFuhcOH2LiEhpBH3BVUUkdevVmwCRyvb7FCAAPeY6U=


### PR DESCRIPTION
# Handle type update and pass indexer E2E tests

This PR results from fixing the type inconsistency for `EvalDelta` in `go-algorand-sdk` (https://github.com/algorand/go-algorand-sdk/pull/531) and passing the [failing nightly test in indexer](https://app.circleci.com/pipelines/github/algorand/indexer/3796/workflows/4016c18f-f298-443e-a887-8cc7dce246f7/jobs/5337).

## NOTE:
This should not be merged until https://github.com/algorand/go-algorand-sdk/pull/531 is merged and the `go.mod` in this project is updated.