### PR TITLE
chore: update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/ @algorand/dev
+.github/ @algorand/lamprey


### PR DESCRIPTION
removing algorand/dev from codeowners to prevent algorand/dev from getting tagged automatically as a PR reviewer.