### PR TITLE
Bug-Fix: don't attempt to get deltas at round 0

### DIFF
--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -230,6 +230,10 @@ func checkRounds(logger *logrus.Logger, catchpointRound, nodeRound, targetRound 
 
 func (algodImp *algodImporter) needsCatchup(targetRound uint64) bool {
 	if algodImp.mode == followerMode {
+		if targetRound == 0 {
+			algodImp.logger.Info("No state deltas are ever available for round 0")
+			return true
+		}
 		// If we are in follower mode, check if the round delta is available.
 		_, err := algodImp.getDelta(targetRound)
 		if err != nil {

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -690,6 +690,7 @@ func TestNeedsCatchup(t *testing.T) {
 	testcases := []struct {
 		name       string
 		mode       int
+		round      uint64
 		responders []algodCustomHandler
 		logMsg     string
 		result     bool
@@ -697,6 +698,7 @@ func TestNeedsCatchup(t *testing.T) {
 		{
 			name:       "Follower mode, no delta",
 			mode:       followerMode,
+			round:      1234,
 			responders: []algodCustomHandler{},
 			logMsg:     "Unable to fetch state delta for round",
 			result:     true,
@@ -704,13 +706,31 @@ func TestNeedsCatchup(t *testing.T) {
 		{
 			name:       "Follower mode, delta",
 			mode:       followerMode,
+			round:      1234,
 			responders: []algodCustomHandler{LedgerStateDeltaResponder},
 			logMsg:     "",
 			result:     false,
 		},
 		{
+			name:       "Follower mode round 0, no delta",
+			mode:       followerMode,
+			round:      0,
+			responders: []algodCustomHandler{},
+			logMsg:     "No state deltas are ever available for round 0",
+			result:     true,
+		},
+		{
+			name:       "Follower mode round 0, delta",
+			mode:       followerMode,
+			round:      0,
+			responders: []algodCustomHandler{LedgerStateDeltaResponder},
+			logMsg:     "No state deltas are ever available for round 0",
+			result:     true,
+		},
+		{
 			name:       "Archival mode, no block",
 			mode:       archivalMode,
+			round:      1234,
 			responders: []algodCustomHandler{},
 			logMsg:     "Unable to fetch block for round",
 			result:     true,
@@ -718,6 +738,7 @@ func TestNeedsCatchup(t *testing.T) {
 		{
 			name:       "Archival mode, block",
 			mode:       archivalMode,
+			round:      1234,
 			responders: []algodCustomHandler{BlockResponder},
 			logMsg:     "",
 			result:     false,
@@ -744,7 +765,7 @@ func TestNeedsCatchup(t *testing.T) {
 				},
 			}
 
-			assert.Equal(t, tc.result, testImporter.needsCatchup(1234))
+			assert.Equal(t, tc.result, testImporter.needsCatchup(tc.round))
 			if tc.logMsg != "" {
 				assert.Len(t, hook.AllEntries(), 1)
 				assert.Contains(t, hook.LastEntry().Message, tc.logMsg)


### PR DESCRIPTION
## Summary
Don't attempt to query deltas from a follower node for round 0. Instead, just declare that we need to catch up and log:
> No state deltas are ever available for round 0

## Test Plan

CI - introduced new unit test cases