### PR TITLE
bug-fix: better configuration of plugin loggers + trace all algod requests

### DIFF
--- a/conduit/pipeline/pipeline.go
+++ b/conduit/pipeline/pipeline.go
@@ -107,7 +107,7 @@ func (p *pipelineImpl) registerPluginMetricsCallbacks() {
 func (p *pipelineImpl) makeConfig(cfg data.NameConfigPair, pluginType plugins.PluginType) (*log.Logger, plugins.PluginConfig, error) {
 	configs, err := yaml.Marshal(cfg.Config)
 	if err != nil {
-		return nil, plugins.PluginConfig{}, fmt.Errorf("makeLoggerAndConfig(): could not serialize config: %w", err)
+		return nil, plugins.PluginConfig{}, fmt.Errorf("makeConfig(): could not serialize config: %w", err)
 	}
 
 	lgr := log.New()
@@ -121,7 +121,7 @@ func (p *pipelineImpl) makeConfig(cfg data.NameConfigPair, pluginType plugins.Pl
 		config.DataDir = path.Join(p.cfg.ConduitArgs.ConduitDataDir, fmt.Sprintf("%s_%s", pluginType, cfg.Name))
 		err = os.MkdirAll(config.DataDir, os.ModePerm)
 		if err != nil {
-			return nil, plugins.PluginConfig{}, fmt.Errorf("makeLoggerAndConfig: unable to create plugin data directory: %w", err)
+			return nil, plugins.PluginConfig{}, fmt.Errorf("makeConfig: unable to create plugin data directory: %w", err)
 		}
 	}
 

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -420,7 +420,7 @@ func (algodImp *algodImporter) GetBlock(rnd uint64) (data.BlockData, error) {
 				return blk, fmt.Errorf("GetBlock ctx error: %w", err)
 			}
 			err = fmt.Errorf("error getting status for round: %w", err)
-			algodImp.logger.Errorf("error getting status for round %d (attempt %d)", rnd, r)
+			algodImp.logger.Errorf("error getting status for round %d (attempt %d): %s", rnd, r, err.Error())
 			continue
 		}
 		start := time.Now()
@@ -428,7 +428,7 @@ func (algodImp *algodImporter) GetBlock(rnd uint64) (data.BlockData, error) {
 		dt := time.Since(start)
 		getAlgodRawBlockTimeSeconds.Observe(dt.Seconds())
 		if err != nil {
-			algodImp.logger.Errorf("error getting block for round %d (attempt %d)", rnd, r)
+			algodImp.logger.Errorf("error getting block for round %d (attempt %d): %s", rnd, r, err.Error())
 			continue
 		}
 		tmpBlk := new(models.BlockResponse)


### PR DESCRIPTION
## Summary

In preparing the bugfix in https://github.com/algorand/go-algorand/pull/5449, I discovered that conduit's logger wasn't printing out at the log-level that I was expecting (TRACE). I made some minor fixes to address this problem and also added the traces that I found helpful. Finally, a couple of logs were missing the received error from algod, so I added these.

## Test Plan

CI + local testing