### PR TITLE
docs: fix filter docs to replace exact.

### DIFF
--- a/conduit/plugins/processors/filterprocessor/README.md
+++ b/conduit/plugins/processors/filterprocessor/README.md
@@ -40,13 +40,12 @@ Example:
 ### `expression-type`
 The expression type is a selection of one of the available methods for evaluating the expression. The current list of
 types is
-* `exact`: exact match for string values.
+* `equal`: exact match for string and numeric values.
 * `regex`:  applies regex rules to the matching.
 * `less-than` applies numerical less than expression.
 * `less-than-equal` applies numerical less than or equal expression.
 * `greater-than` applies numerical greater than expression.
 * `greater-than-equal` applies numerical greater than or equal expression.
-* `equal` applies numerical equal expression.
 * `not-equal` applies numerical not equal expression.
 
 You must use the proper expression type for the field your tag identifies based on the type of data stored in that field.
@@ -74,7 +73,7 @@ config:
     filters:
       - any:
           - tag: txn.rcv
-            expression-type: exact
+            expression-type: equal
             expression: "ADDRESS"
 ```
 
@@ -94,7 +93,7 @@ Find state proof transactions
 filters:
   - any:
     - tag: "txn.type"
-      expression-type: "exact"
+      expression-type: "equal"
       expression: "stpf"
 ```
 
@@ -103,10 +102,10 @@ Find transactions calling app, "MYAPPID"
 filters:
   - all:
     - tag: "txn.type"
-      expression-type: "exact"
+      expression-type: "equal"
       expression: "appl"
     - tag: "txn.apid"
-      expression-type: "exact"
+      expression-type: "equal"
       expression: "MYAPPID"
 ```
 
@@ -116,7 +115,7 @@ search-inner: true
 filters:
   - all:
     - tag: "txn.snd"
-      expression-type: "exact"
+      expression-type: "equal"
       expression: "FOO"
 ```
 
@@ -126,6 +125,6 @@ omit-group-transactions: true
 filters:
   - all:
     - tag: "txn.type"
-      expression-type: "exact"
+      expression-type: "equal"
       expression: "appl"
 ```

--- a/conduit/plugins/processors/filterprocessor/README.md
+++ b/conduit/plugins/processors/filterprocessor/README.md
@@ -72,8 +72,8 @@ config:
     # The list of filter expressions to use when matching transactions.
     filters:
       - any:
-          - tag: txn.rcv
-            expression-type: equal
+          - tag: "txn.rcv"
+            expression-type: "equal"
             expression: "ADDRESS"
 ```
 

--- a/conduit/plugins/processors/filterprocessor/config.go
+++ b/conduit/plugins/processors/filterprocessor/config.go
@@ -19,7 +19,6 @@ type SubConfig struct {
 	FilterTag string `yaml:"tag"`
 	/* <code>expression-type</code> is the type of comparison applied between the field, identified by the tag, and the expression.<br/>
 	<ul>
-		<li>exact</li>
 		<li>regex</li>
 		<li>less-than</li>
 		<li>less-than-equal</li>

--- a/conduit/plugins/processors/filterprocessor/sample.yaml
+++ b/conduit/plugins/processors/filterprocessor/sample.yaml
@@ -11,5 +11,5 @@ config:
     filters:
       - any:
           - tag: txn.rcv
-            expression-type: exact
+            expression-type: equal
             expression: "ADDRESS"

--- a/conduit/plugins/processors/filterprocessor/sample.yaml
+++ b/conduit/plugins/processors/filterprocessor/sample.yaml
@@ -10,6 +10,6 @@ config:
     # The list of filter expressions to use when matching transactions.
     filters:
       - any:
-          - tag: txn.rcv
-            expression-type: equal
+          - tag: "txn.rcv"
+            expression-type: "equal"
             expression: "ADDRESS"

--- a/docs/tutorials/WritingBlocksToFile.md
+++ b/docs/tutorials/WritingBlocksToFile.md
@@ -145,7 +145,7 @@ config:
   filters:
     - any:
       - tag: txn.rcv
-        expression-type: exact
+        expression-type: equal
         expression: "ADDRESS"
 ```
 

--- a/docs/tutorials/WritingBlocksToFile.md
+++ b/docs/tutorials/WritingBlocksToFile.md
@@ -144,8 +144,8 @@ config:
   # See README for more info.
   filters:
     - any:
-      - tag: txn.rcv
-        expression-type: equal
+      - tag: "txn.rcv"
+        expression-type: "equal"
         expression: "ADDRESS"
 ```
 


### PR DESCRIPTION
## Summary

The equal and exact types were merged in https://github.com/algorand/indexer/pull/1468 but the documentation was not properly updated. This PR updates the documentation to replace `exact` with `equal`.