### PR TITLE
Fix typo on conduit configuration file

### DIFF
--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -12,7 +12,7 @@ Special locations in the container designed to modify behavior:
 
 | File | Description |
 | ---- | ----------- |
-| /etc/algorand/config.yml | Required. Conduit configuration file. Definition for the pipeline behavior. |
+| /etc/algorand/conduit.yml | Required. Conduit configuration file. Definition for the pipeline behavior. |
 | /data | Optional. Data directory. For persistence you may mount a volume at this location. See volume permissions sections for additional information. |
 
 # Usage


### PR DESCRIPTION
## Summary

Fixes typo on Docker documentation. The entry point is using `cp /etc/algorand/conduit.yml /data/conduit.yml` and the documentation refers to `config.yml`

## Test Plan

I didn't test the changes, I think they can be validated by inspection.
