### PR TITLE
Pipeline the Pipeline

### DIFF
--- a/conduit/pipeline/metadata_test.go
+++ b/conduit/pipeline/metadata_test.go
@@ -31,7 +31,7 @@ func TestSamples(t *testing.T) {
 func TestBlockMetaDataFile(t *testing.T) {
 	datadir := t.TempDir()
 	pipelineMetadata := state{
-		NextRound: 3,
+		NextRoundDEPRECATED: 3,
 	}
 
 	// Test the file is not created yet
@@ -52,20 +52,20 @@ func TestBlockMetaDataFile(t *testing.T) {
 	metaData, err := readBlockMetadata(datadir)
 	assert.NoError(t, err)
 	assert.Equal(t, pipelineMetadata.GenesisHash, metaData.GenesisHash)
-	assert.Equal(t, pipelineMetadata.NextRound, metaData.NextRound)
+	assert.Equal(t, pipelineMetadata.NextRoundDEPRECATED, metaData.NextRoundDEPRECATED)
 	assert.Equal(t, pipelineMetadata.Network, metaData.Network)
 	assert.Equal(t, pipelineMetadata.TelemetryID, metaData.TelemetryID)
 
 	// Test that file encodes correctly
 	pipelineMetadata.GenesisHash = "HASH"
-	pipelineMetadata.NextRound = 7
+	pipelineMetadata.NextRoundDEPRECATED = 7
 	pipelineMetadata.TelemetryID = "SOME_ID"
 	err = pipelineMetadata.encodeToFile(datadir)
 	assert.NoError(t, err)
 	metaData, err = readBlockMetadata(datadir)
 	assert.NoError(t, err)
 	assert.Equal(t, "HASH", metaData.GenesisHash)
-	assert.Equal(t, uint64(7), metaData.NextRound)
+	assert.Equal(t, uint64(7), metaData.NextRoundDEPRECATED)
 	assert.Equal(t, pipelineMetadata.Network, metaData.Network)
 	assert.Equal(t, pipelineMetadata.TelemetryID, metaData.TelemetryID)
 }

--- a/conduit/pipeline/pipeline.go
+++ b/conduit/pipeline/pipeline.go
@@ -613,7 +613,7 @@ func (p *pipelineImpl) oneRoundWithRetries(round uint64, preExportSignal roundCo
 type roundComplete chan struct{}
 
 // Start pushes block data through the pipeline
-func (p *pipelineImpl) Start() {
+func (p *pipelineImpl) ZStart() {
 	p.logger.Debug("Pipeline.Start()")
 
 	concurrentRounds := uint64(11) // TODO: make this configurable

--- a/conduit/pipeline/pipeline.go
+++ b/conduit/pipeline/pipeline.go
@@ -354,7 +354,7 @@ func (p *pipelineImpl) Init() error {
 		}
 		err = (*p.exporter).Init(p.ctx, *p.initProvider, config, logger)
 		if err != nil {
-			return fmt.Errorf("Pipeline.Start(): could not initialize Exporter (%s): %w", p.cfg.Exporter.Name, err)
+			return fmt.Errorf("Pipeline.Init(): could not initialize Exporter (%s): %w", p.cfg.Exporter.Name, err)
 		}
 		p.logger.Infof("Initialized Exporter: %s", p.cfg.Exporter.Name)
 	}

--- a/conduit/pipeline/pipeline_bench_test.go
+++ b/conduit/pipeline/pipeline_bench_test.go
@@ -3,7 +3,6 @@ package pipeline
 import (
 	"context"
 	"fmt"
-	"math"
 	"testing"
 	"time"
 
@@ -18,7 +17,8 @@ import (
 )
 
 const (
-	logLevel = log.ErrorLevel
+	logLevel   = log.ErrorLevel // log.DebugLevel //
+	retryCount = 3              // math.MaxUint64
 )
 
 type sleepingImporter struct {
@@ -209,12 +209,12 @@ func pipeline5sec(b *testing.B, testCase benchmarkCase) int {
 		processors:   processors,
 		exporter:     exporter,
 		pipelineMetadata: state{
-			NextRound:   0,
-			GenesisHash: "",
+			NextRoundDEPRECATED: 0,
+			GenesisHash:         "",
 		},
 		cfg: &data.Config{
 			RetryDelay: 0 * time.Second,
-			RetryCount: math.MaxUint64,
+			RetryCount: retryCount,
 			ConduitArgs: &data.Args{
 				ConduitDataDir: b.TempDir(),
 			},

--- a/conduit/pipeline/pipeline_bench_test.go
+++ b/conduit/pipeline/pipeline_bench_test.go
@@ -189,7 +189,6 @@ func pipeline5sec(b *testing.B, bcCase benchmarkCase) int {
 		sprocs[i] = &sleepingProcessor{processSleep: pSleep}
 	}
 	slexpo := &sleepingExporter{receiveSleep: bcCase.exporterSleep}
-	// var cbComplete conduit.Completed = &mProcessor
 
 	ctx, cf := context.WithCancel(context.Background())
 

--- a/conduit/pipeline/pipeline_bench_test.go
+++ b/conduit/pipeline/pipeline_bench_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	logLevel   = log.ErrorLevel // log.DebugLevel //
+	logLevel   = log.ErrorLevel //log.InfoLevel // log.DebugLevel //
 	retryCount = 3              // math.MaxUint64
 )
 

--- a/conduit/pipeline/pipeline_bench_test.go
+++ b/conduit/pipeline/pipeline_bench_test.go
@@ -1,0 +1,298 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/algorand/conduit/conduit/data"
+	"github.com/algorand/conduit/conduit/plugins"
+	"github.com/algorand/conduit/conduit/plugins/processors"
+	sdk "github.com/algorand/go-algorand-sdk/v2/types"
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type sleepingImporter struct {
+	// importers.Importer
+	cfg             plugins.PluginConfig
+	genesis         sdk.Genesis
+	finalRound      sdk.Round
+	getBlockSleep   time.Duration // when non-0, sleep when GetBlock() even in the case of an error
+	returnError     bool
+	onCompleteError bool
+	subsystem       string
+	rndOverride     uint64
+	rndReqErr       error
+}
+
+func (m *sleepingImporter) Init(_ context.Context, _ data.InitProvider, cfg plugins.PluginConfig, _ *log.Logger) error {
+	m.cfg = cfg
+	return nil
+}
+
+func (m *sleepingImporter) GetGenesis() (*sdk.Genesis, error) {
+	return &m.genesis, nil
+}
+
+func (m *sleepingImporter) Close() error {
+	return nil
+}
+
+func (m *sleepingImporter) Metadata() plugins.Metadata {
+	return plugins.Metadata{Name: "sleepingImporter"}
+}
+
+func (m *sleepingImporter) GetBlock(rnd uint64) (data.BlockData, error) {
+	if m.getBlockSleep > 0 {
+		time.Sleep(m.getBlockSleep)
+	}
+	var err error
+	if m.returnError {
+		err = fmt.Errorf("importer")
+	}
+	return data.BlockData{BlockHeader: sdk.BlockHeader{Round: sdk.Round(rnd)}}, err
+}
+
+func (m *sleepingImporter) OnComplete(input data.BlockData) error {
+	var err error
+	if m.onCompleteError {
+		err = fmt.Errorf("on complete")
+	}
+	m.finalRound = sdk.Round(input.BlockHeader.Round)
+	return err
+}
+
+func (m *sleepingImporter) ProvideMetrics(subsystem string) []prometheus.Collector {
+	m.subsystem = subsystem
+	return nil
+}
+
+func (m *sleepingImporter) RoundRequest(_ plugins.PluginConfig) (uint64, error) {
+	return m.rndOverride, m.rndReqErr
+}
+
+type sleepingProcessor struct {
+	// processors.Processor
+	cfg             plugins.PluginConfig
+	finalRound      sdk.Round
+	processSleep    time.Duration // when non-0, sleep when Process() even in the case of an error
+	returnError     bool
+	onCompleteError bool
+	rndOverride     uint64
+	rndReqErr       error
+}
+
+func (m *sleepingProcessor) Init(_ context.Context, _ data.InitProvider, cfg plugins.PluginConfig, _ *log.Logger) error {
+	m.cfg = cfg
+	return nil
+}
+
+func (m *sleepingProcessor) Close() error {
+	return nil
+}
+
+func (m *sleepingProcessor) RoundRequest(_ plugins.PluginConfig) (uint64, error) {
+	return m.rndOverride, m.rndReqErr
+}
+
+func (m *sleepingProcessor) Metadata() plugins.Metadata {
+	return plugins.Metadata{
+		Name: "sleepingProcessor",
+	}
+}
+
+func (m *sleepingProcessor) Process(input data.BlockData) (data.BlockData, error) {
+	if m.processSleep > 0 {
+		time.Sleep(m.processSleep)
+	}
+	var err error
+	if m.returnError {
+		err = fmt.Errorf("process")
+	}
+	input.BlockHeader.Round++
+	return input, err
+}
+
+func (m *sleepingProcessor) OnComplete(input data.BlockData) error {
+	var err error
+	if m.onCompleteError {
+		err = fmt.Errorf("on complete")
+	}
+	m.finalRound = sdk.Round(input.BlockHeader.Round)
+	return err
+}
+
+type sleepingExporter struct {
+	// exporters.Exporter
+	cfg             plugins.PluginConfig
+	finalRound      sdk.Round
+	receiveSleep    time.Duration // when non-0, sleep when Receive() even in the case of an error
+	returnError     bool
+	onCompleteError bool
+	rndOverride     uint64
+	rndReqErr       error
+}
+
+func (m *sleepingExporter) Metadata() plugins.Metadata {
+	return plugins.Metadata{
+		Name: "sleepingExporter",
+	}
+}
+
+func (m *sleepingExporter) RoundRequest(_ plugins.PluginConfig) (uint64, error) {
+	return m.rndOverride, m.rndReqErr
+}
+
+func (m *sleepingExporter) Init(_ context.Context, _ data.InitProvider, cfg plugins.PluginConfig, _ *log.Logger) error {
+	m.cfg = cfg
+	return nil
+}
+
+func (m *sleepingExporter) Close() error {
+	return nil
+}
+
+func (m *sleepingExporter) Receive(exportData data.BlockData) error {
+	if m.receiveSleep > 0 {
+		time.Sleep(m.receiveSleep)
+	}
+	var err error
+	if m.returnError {
+		err = fmt.Errorf("receive")
+	}
+	return err
+}
+
+func (m *sleepingExporter) OnComplete(input data.BlockData) error {
+	var err error
+	if m.onCompleteError {
+		err = fmt.Errorf("on complete")
+	}
+	m.finalRound = sdk.Round(input.BlockHeader.Round)
+	return err
+}
+
+// func pipeline100ms(i int) int {
+// 	// your code here
+// 	time.Sleep(1 * time.Millisecond)
+// 	return i // dummy return
+// }
+
+type benchmarkCase struct {
+	name            string
+	importerSleep   time.Duration
+	processorsSleep []time.Duration
+	exporterSleep   time.Duration
+}
+
+func pipeline5sec(b *testing.B, bcCase benchmarkCase) int {
+	simp := &sleepingImporter{getBlockSleep: bcCase.importerSleep}
+	sprocs := make([]processors.Processor, len(bcCase.processorsSleep))
+	for i, pSleep := range bcCase.processorsSleep {
+		sprocs[i] = &sleepingProcessor{processSleep: pSleep}
+	}
+	slexpo := &sleepingExporter{receiveSleep: bcCase.exporterSleep}
+	// var cbComplete conduit.Completed = &mProcessor
+
+	ctx, cf := context.WithCancel(context.Background())
+
+	l, _ := test.NewNullLogger()
+	pImpl := pipelineImpl{
+		ctx:          ctx,
+		cf:           cf,
+		logger:       l,
+		initProvider: nil,
+		importer:     simp,
+		processors:   sprocs,
+		exporter:     slexpo,
+		// completeCallback: []conduit.OnCompleteFunc{cbComplete.OnComplete},
+		pipelineMetadata: state{
+			NextRound:   0,
+			GenesisHash: "",
+		},
+		cfg: &data.Config{
+			RetryDelay: 0 * time.Second,
+			RetryCount: math.MaxUint64,
+			ConduitArgs: &data.Args{
+				ConduitDataDir: b.TempDir(),
+			},
+		},
+	}
+
+	pImpl.registerLifecycleCallbacks()
+
+	// cancel the pipeline after 1 second
+	go func() {
+		time.Sleep(5 * time.Second)
+		cf()
+	}()
+
+	b.StartTimer()
+	pImpl.Start()
+	pImpl.Wait()
+	assert.NoError(b, pImpl.Error())
+
+	fRound, err := finalRound(&pImpl)
+	require.NoError(b, err)
+	return int(fRound)
+}
+
+func finalRound(pi *pipelineImpl) (sdk.Round, error) {
+	if mExp, ok := pi.exporter.(*sleepingExporter); ok {
+		return mExp.finalRound, nil
+	}
+	return 0, fmt.Errorf("not a sleepingExporter: %t", pi.exporter)
+}
+
+func BenchmarkPipeline(b *testing.B) {
+	benchCases := []benchmarkCase{
+		{
+			name:            "vanilla 2 procs without sleep",
+			importerSleep:   0,
+			processorsSleep: []time.Duration{0, 0},
+			exporterSleep:   0,
+		},
+		{
+			name:            "uniform sleep of 10ms",
+			importerSleep:   10 * time.Millisecond,
+			processorsSleep: []time.Duration{10 * time.Millisecond, 10 * time.Millisecond},
+			exporterSleep:   10 * time.Millisecond,
+		},
+		{
+			name:            "exporter 10ms while others 1ms",
+			importerSleep:   time.Millisecond,
+			processorsSleep: []time.Duration{time.Millisecond, time.Millisecond},
+			exporterSleep:   10 * time.Millisecond,
+		},
+		{
+			name:            "importer 10ms while others 1ms",
+			importerSleep:   10 * time.Millisecond,
+			processorsSleep: []time.Duration{time.Millisecond, time.Millisecond},
+			exporterSleep:   time.Millisecond,
+		},
+		{
+			name:            "first processor 10ms while others 1ms",
+			importerSleep:   time.Millisecond,
+			processorsSleep: []time.Duration{10 * time.Millisecond, time.Millisecond},
+			exporterSleep:   time.Millisecond,
+		},
+	}
+	for _, bc := range benchCases {
+		b.Run(bc.name, func(b *testing.B) {
+			rounds := 0
+			for i := 0; i < b.N; i++ {
+				rounds += pipeline5sec(b, bc)
+			}
+			secs := b.Elapsed().Seconds()
+			rps := float64(rounds) / secs
+			// fmt.Printf("benchmark warmup results. N: %d, elapsed: %f, rounds/sec: %f\n", b.N, secs, rps)
+			b.ReportMetric(rps, "rounds/sec")
+		})
+	}
+}

--- a/conduit/pipeline/pipeline_bench_test.go
+++ b/conduit/pipeline/pipeline_bench_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 type sleepingImporter struct {
-	// importers.Importer
 	cfg             plugins.PluginConfig
 	genesis         sdk.Genesis
 	finalRound      sdk.Round
@@ -78,7 +77,6 @@ func (m *sleepingImporter) RoundRequest(_ plugins.PluginConfig) (uint64, error) 
 }
 
 type sleepingProcessor struct {
-	// processors.Processor
 	cfg             plugins.PluginConfig
 	finalRound      sdk.Round
 	processSleep    time.Duration // when non-0, sleep when Process() even in the case of an error
@@ -129,7 +127,6 @@ func (m *sleepingProcessor) OnComplete(input data.BlockData) error {
 }
 
 type sleepingExporter struct {
-	// exporters.Exporter
 	cfg             plugins.PluginConfig
 	finalRound      sdk.Round
 	receiveSleep    time.Duration // when non-0, sleep when Receive() even in the case of an error
@@ -178,12 +175,6 @@ func (m *sleepingExporter) OnComplete(input data.BlockData) error {
 	return err
 }
 
-// func pipeline100ms(i int) int {
-// 	// your code here
-// 	time.Sleep(1 * time.Millisecond)
-// 	return i // dummy return
-// }
-
 type benchmarkCase struct {
 	name            string
 	importerSleep   time.Duration
@@ -211,7 +202,6 @@ func pipeline5sec(b *testing.B, bcCase benchmarkCase) int {
 		importer:     simp,
 		processors:   sprocs,
 		exporter:     slexpo,
-		// completeCallback: []conduit.OnCompleteFunc{cbComplete.OnComplete},
 		pipelineMetadata: state{
 			NextRound:   0,
 			GenesisHash: "",

--- a/conduit/pipeline/pipeline_test.go
+++ b/conduit/pipeline/pipeline_test.go
@@ -237,9 +237,9 @@ func mockPipeline(t *testing.T, dataDir string) (*pipelineImpl, *test.Hook, *moc
 		processors:   []processors.Processor{pProcessor},
 		exporter:     pExporter,
 		pipelineMetadata: state{
-			GenesisHash: "",
-			Network:     "",
-			NextRound:   3,
+			GenesisHash:         "",
+			Network:             "",
+			NextRoundDEPRECATED: 3,
 		},
 	}
 
@@ -276,8 +276,8 @@ func TestPipelineRun(t *testing.T) {
 		exporter:         pExporter,
 		completeCallback: []conduit.OnCompleteFunc{cbComplete.OnComplete},
 		pipelineMetadata: state{
-			NextRound:   0,
-			GenesisHash: "",
+			NextRoundDEPRECATED: 0,
+			GenesisHash:         "",
 		},
 		cfg: &data.Config{
 			RetryDelay: 0 * time.Second,
@@ -662,7 +662,7 @@ func TestRoundOverride(t *testing.T) {
 			pImpl.cfg.ConduitArgs.NextRoundOverride = uint64(i)
 			err := pImpl.Init()
 			assert.Nil(t, err)
-			assert.Equal(t, uint64(i), pImpl.pipelineMetadata.NextRound)
+			assert.Equal(t, uint64(i), pImpl.pipelineMetadata.NextRoundDEPRECATED)
 		})
 	}
 
@@ -672,7 +672,7 @@ func TestRoundOverride(t *testing.T) {
 		mImporter.rndOverride = 10
 		err := pImpl.Init()
 		assert.Nil(t, err)
-		assert.Equal(t, uint64(10), pImpl.pipelineMetadata.NextRound)
+		assert.Equal(t, uint64(10), pImpl.pipelineMetadata.NextRoundDEPRECATED)
 	})
 
 	t.Run("processor round override", func(t *testing.T) {
@@ -681,7 +681,7 @@ func TestRoundOverride(t *testing.T) {
 		mProcessor.rndOverride = 10
 		err := pImpl.Init()
 		assert.Nil(t, err)
-		assert.Equal(t, uint64(10), pImpl.pipelineMetadata.NextRound)
+		assert.Equal(t, uint64(10), pImpl.pipelineMetadata.NextRoundDEPRECATED)
 	})
 
 	t.Run("exporter round override", func(t *testing.T) {
@@ -690,7 +690,7 @@ func TestRoundOverride(t *testing.T) {
 		mExporter.rndOverride = 10
 		err := pImpl.Init()
 		assert.Nil(t, err)
-		assert.Equal(t, uint64(10), pImpl.pipelineMetadata.NextRound)
+		assert.Equal(t, uint64(10), pImpl.pipelineMetadata.NextRoundDEPRECATED)
 	})
 }
 
@@ -801,9 +801,9 @@ func TestPipelineRetryVariables(t *testing.T) {
 				processors:   []processors.Processor{pProcessor},
 				exporter:     pExporter,
 				pipelineMetadata: state{
-					GenesisHash: "",
-					Network:     "",
-					NextRound:   3,
+					GenesisHash:         "",
+					Network:             "",
+					NextRoundDEPRECATED: 3,
 				},
 				wg: sync.WaitGroup{},
 			}

--- a/conduit/pipeline/winder.go
+++ b/conduit/pipeline/winder.go
@@ -1,0 +1,87 @@
+package pipeline
+
+import (
+	"time"
+
+	"github.com/algorand/conduit/conduit/data"
+	"github.com/algorand/conduit/conduit/metrics"
+	"github.com/algorand/conduit/conduit/plugins/exporters"
+	"github.com/algorand/conduit/conduit/plugins/importers"
+	"github.com/algorand/conduit/conduit/plugins/processors"
+)
+
+func (p *pipelineImpl) ImportHandler(importer importers.Importer, inChan <-chan uint64, outChan chan<- data.BlockData, errChan chan<- error) {
+	select {
+	case <-p.ctx.Done():
+	case rnd := <-inChan:
+		var lastError error
+		retry := uint64(0)
+		for retry > p.cfg.RetryCount && p.cfg.RetryCount != 0 {
+			importStart := time.Now()
+			blkData, err := importer.GetBlock(rnd)
+			if err != nil {
+				p.logger.Errorf("%v", err)
+				retry++
+				lastError = err
+				continue
+			}
+
+			metrics.ImporterTimeSeconds.Observe(time.Since(importStart).Seconds())
+			outChan <- blkData
+			lastError = nil
+		}
+		if lastError != nil {
+			errChan <- lastError
+			return
+		}
+	}
+}
+
+func (p *pipelineImpl) ProcessorHandler(importer processors.Processor, inChan <-chan data.BlockData, outChan chan<- data.BlockData, errChan chan<- error) {
+}
+
+func (p *pipelineImpl) ExporterHandler(importer exporters.Exporter, inChan <-chan data.BlockData, errChan chan<- error) {
+}
+
+// Start pushes block data through the pipeline
+func (p *pipelineImpl) WStart() {
+	// Setup channels
+	roundChan := make(chan uint64)
+	processorBlkInChan := make(chan data.BlockData)
+	errChan := make(chan error)
+	p.ImportHandler(p.importer, roundChan, processorBlkInChan, errChan)
+
+	var processorBlkOutChan chan data.BlockData
+	for _, proc := range p.processors {
+		processorBlkOutChan = make(chan data.BlockData)
+		p.ProcessorHandler(proc, processorBlkInChan, processorBlkOutChan, errChan)
+		processorBlkInChan = processorBlkOutChan
+	}
+
+	p.ExporterHandler(p.exporter, processorBlkOutChan, errChan)
+
+	p.wg.Add(1)
+	// Main loop
+	go func(startRound uint64) {
+		defer p.wg.Done()
+		defer close(errChan)
+		rnd := startRound
+		for {
+			select {
+			case <-p.ctx.Done():
+				return
+			case roundChan <- rnd:
+				rnd++
+			}
+		}
+	}(p.pipelineMetadata.NextRoundDEPRECATED)
+
+	// Check for errors
+	for err := range errChan {
+		if err != nil {
+			p.logger.Errorf("%v", err)
+			p.setError(err) // TODO: probably it's better to p.joinError(...)
+			return
+		}
+	}
+}

--- a/conduit/pipeline/winder.go
+++ b/conduit/pipeline/winder.go
@@ -168,7 +168,7 @@ func (p *pipelineImpl) Start() {
 		processorBlkInChan = processorBlkOutChan
 	}
 
-	p.ExporterHandler(p.exporter, processorBlkInChan, errChan)
+	p.ExporterHandler(p.exporter, processorBlkOutChan, errChan)
 
 	p.wg.Add(1)
 	// Main loop

--- a/conduit/plugins/exporters/postgresql/README.md
+++ b/conduit/plugins/exporters/postgresql/README.md
@@ -9,7 +9,8 @@ The database maintained by this plugin is designed to serve the Indexer API.
 The connection string is defined by the [pgx](https://github.com/jackc/pgconn) database driver.
 
 For most deployments, you can use the following format:
-```
+
+```psql
 host={url} port={port} user={user} password={password} dbname={db_name} sslmode={enable|disable}
 ```
 
@@ -20,6 +21,7 @@ For additional details, refer to the [parsing documentation here](https://pkg.go
 The delete-task prunes old transactions according to its configuration. This can be used to limit the size of the database.
 
 ## Configuration
+
 ```yml @sample.yaml
 name: postgresql
 config:
@@ -41,4 +43,103 @@ config:
     
         # Rounds to keep
         rounds: 100000
+```
+
+## TODO - Mermaid
+
+```mermaid
+graph TD
+    roundChan((roundChan))
+    importedBlocksChan((importedBlocksChan))
+    processorChans0("processorChans[0]")
+    processorChans1("processorChans[1]")
+    exporterChan((exporterChan))
+
+    roundChan -->|inChan| ImportHandler1[ImportHandler 1]
+    roundChan -->|inChan| ImportHandler2[ImportHandler 2]
+    roundChan -->|inChan| ImportHandler3[ImportHandler 3]
+    ImportHandler1 -->|result| importedBlocksChan
+    ImportHandler2 -->|result| importedBlocksChan
+    ImportHandler3 -->|result| importedBlocksChan
+
+    importedBlocksChan --> OrderResults[Order Results]
+    OrderResults --> processorChans0
+
+    processorChans0 --> ProcessHandler1[ProcessHandler 1]
+    ProcessHandler1 --> processorChans1
+
+    processorChans1 --> ProcessHandler2[ProcessHandler 2]
+    ProcessHandler2 --> exporterChan
+
+    exporterChan --> ExportHandler[ExportHandler]
+```
+
+### V2
+
+```mermaid
+graph TD
+    style roundChan fill:#f9f,stroke:#333,stroke-width:2px
+    style importedBlocksChan fill:#f9f,stroke:#333,stroke-width:2px
+    style processorChans0 fill:#f9f,stroke:#333,stroke-width:2px
+    style processorChans1 fill:#f9f,stroke:#333,stroke-width:2px
+    style exporterChan fill:#f9f,stroke:#333,stroke-width:2px
+
+    roundChan[[roundChan]]
+    importedBlocksChan[[importedBlocksChan]]
+    processorChans0("processorChans[0]")
+    processorChans1("processorChans[1]")
+    exporterChan[[exporterChan]]
+
+    roundChan -->|inChan| BlockGetter1((BlockGetter 1))
+    roundChan -->|inChan| BlockGetter2((BlockGetter 2))
+    roundChan -->|inChan| BlockGetter3((BlockGetter 3))
+    BlockGetter1 -->|result| importedBlocksChan
+    BlockGetter2 -->|result| importedBlocksChan
+    BlockGetter3 -->|result| importedBlocksChan
+
+    importedBlocksChan --> OrderResults((Order Results))
+    OrderResults --> processorChans0
+
+    processorChans0 --> ProcessHandler1((ProcessHandler 1))
+    ProcessHandler1 --> processorChans1
+
+    processorChans1 --> ProcessHandler2((ProcessHandler 2))
+    ProcessHandler2 --> exporterChan
+
+    exporterChan --> ExportHandler((ExportHandler))
+```
+
+### V3
+
+```mermaid
+graph LR
+    style roundChan fill:#f9f,stroke:#333,stroke-width:2px
+    style importedBlocksChan fill:#f9f,stroke:#333,stroke-width:2px
+    style processorChans0 fill:#f9f,stroke:#333,stroke-width:2px
+    style exporterChan fill:#f9f,stroke:#333,stroke-width:2px
+
+    roundChan[[roundChan]]
+    processorChans0("processorChans[0]")
+    exporterChan[[exporterChan]]
+
+    roundChan -->|inChan| BlockGetter1((BlockGetter 1))
+    roundChan -->|inChan| BlockGetter2((BlockGetter 2))
+    roundChan -->|inChan| BlockGetter3((BlockGetter 3))
+
+    subgraph ImportHandler
+        importedBlocksChan[[importedBlocksChan]]
+        
+        BlockGetter1 -->|result| importedBlocksChan
+        BlockGetter2 -->|result| importedBlocksChan
+        BlockGetter3 -->|result| importedBlocksChan
+
+        importedBlocksChan --> OrderResults((Order Results))
+    end
+
+    OrderResults --> processorChans0
+
+    processorChans0 --> ProcessHandler1((ProcessHandler 1))
+    ProcessHandler1 --> exporterChan
+
+    exporterChan --> ExportHandler((ExportHandler))
 ```

--- a/conduit/types/broadcaster.go
+++ b/conduit/types/broadcaster.go
@@ -1,0 +1,75 @@
+package types
+
+import (
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type Broadcaster[T any] struct {
+	subscribers map[*Subscriber[T]]struct{}
+	mu          sync.RWMutex
+
+	logger *log.Logger
+}
+
+type Subscriber[T any] struct {
+	Chan   chan T
+	closed chan struct{}
+	once   sync.Once
+}
+
+func NewBroadcaster[T any](logger *log.Logger) *Broadcaster[T] {
+	return &Broadcaster[T]{
+		subscribers: make(map[*Subscriber[T]]struct{}),
+		logger:      logger,
+	}
+}
+
+func (b *Broadcaster[T]) Subscribe() *Subscriber[T] {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	sub := &Subscriber[T]{
+		Chan:   make(chan T, 1),
+		closed: make(chan struct{}),
+	}
+
+	b.subscribers[sub] = struct{}{}
+
+	b.logger.Debugf("Subscribe() resulting in %d total subscribers", len(b.subscribers))
+	return sub
+}
+
+func (b *Broadcaster[T]) Broadcast(t T) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	for sub := range b.subscribers {
+		go func(sub *Subscriber[T], t T) {
+			select {
+			case <-sub.closed:
+			case sub.Chan <- t:
+			}
+		}(sub, t)
+	}
+}
+
+func (s *Subscriber[T]) Get() T {
+	return <-s.Chan
+}
+
+func (s *Subscriber[T]) Close() {
+	s.once.Do(func() {
+		close(s.Chan)
+		close(s.closed)
+	})
+}
+
+func (b *Broadcaster[T]) Unsubscribe(s *Subscriber[T]) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	delete(b.subscribers, s)
+	s.Close()
+}

--- a/conduit/types/broadcaster_test.go
+++ b/conduit/types/broadcaster_test.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBroadcaster(t *testing.T) {
+	b := NewBroadcaster[int](nil)
+
+	// Test Subscribe
+	sub1 := b.Subscribe()
+	require.NotNil(t, sub1, "Expected subscriber, got nil")
+	sub2 := b.Subscribe()
+	require.NotNil(t, sub2, "Expected subscriber, got nil")
+
+	// Test Broadcast and Get
+	b.Broadcast(10)
+	val := sub1.Get()
+	require.Equal(t, 10, val, "Expected 10, got %d", val)
+	val = sub2.Get()
+	require.Equal(t, 10, val, "Expected 10, got %d", val)
+
+	// Test Close
+	sub1.Close()
+	if sub1 != nil {
+		select {
+		case <-sub1.closed:
+		case <-time.After(time.Second):
+			t.Error("Expected subscriber to be closed")
+		}
+	}
+
+	// Test Unsubscribe
+	b.Unsubscribe(sub1)
+	b.mu.RLock()
+	_, ok := b.subscribers[sub1]
+	b.mu.RUnlock()
+	require.False(t, ok, "Expected subscriber to be unsubscribed")
+
+	// Test that closed subscriber does not receive broadcasts
+	b.Broadcast(20)
+	val = sub2.Get()
+	require.Equal(t, 20, val, "Expected 20, got %d", val)
+
+	// Check if sub1.ch is closed
+	_, ok = <-sub1.ch
+	require.False(t, ok, "Expected sub1.ch to be closed")
+}

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -56,7 +56,7 @@ Generally speaking, you can follow the code in one of the existing plugins.
 
 ### Init
 
-Each plugin will have its `Init` function called once as the pipline is constructed.
+Each plugin will have its `Init` function called once as the pipeline is constructed.
 
 The context provided to this function should be saved, and used to terminate any long-running operations if necessary.
 


### PR DESCRIPTION
## WIP: Data Pipelining

Not ready for review

## Related Issues
* #11 

## Test Plan

### Baseline Benchmark (before commencing any changes)
* `vanilla_2_procs_without_sleep`
  * 3164 rounds/sec 
* `uniform_sleep_of_10ms`
  * 22.94 rounds/sec   
* `exporter_10ms_while_others_1ms`
  * 64.31 rounds/sec   
* `importer_10ms_while_others_1ms`
  * 63.99 rounds/sec   
* `first_processor_10ms_while_others_1ms`
  * 62.35 rounds/sec   


#### Evidence
```sh
go test -benchmem -run=^$ -bench ^BenchmarkPipeline$ github.com/algorand/conduit/conduit/pipeline -timeout 5m -benchtime 10s

=== RUN   BenchmarkPipeline
BenchmarkPipeline

=== RUN   BenchmarkPipeline/vanilla_2_procs_without_sleep
BenchmarkPipeline/vanilla_2_procs_without_sleep-8                      2        5001635592 ns/op                3164 rounds/sec   56055256 B/op     838342 allocs/op

=== RUN   BenchmarkPipeline/uniform_sleep_of_10ms
BenchmarkPipeline/uniform_sleep_of_10ms-8                              2        5034083494 ns/op                22.94 rounds/sec    350900 B/op       5932 allocs/op

=== RUN   BenchmarkPipeline/exporter_10ms_while_others_1ms
BenchmarkPipeline/exporter_10ms_while_others_1ms-8                     2        5015005884 ns/op                64.31 rounds/sec   1040404 B/op      16608 allocs/op

=== RUN   BenchmarkPipeline/importer_10ms_while_others_1ms
BenchmarkPipeline/importer_10ms_while_others_1ms-8                     2        5001010800 ns/op                63.99 rounds/sec   1034500 B/op      16483 allocs/op

=== RUN   BenchmarkPipeline/first_processor_10ms_while_others_1ms
BenchmarkPipeline/first_processor_10ms_while_others_1ms-8              2        5011949026 ns/op                62.35 rounds/sec   1035548 B/op      16084 allocs/op
```

### After pipelining the pipeline - the original approach

#### statistics

* `vanilla_2_procs_without_sleep`
  * 3969 rounds/sec (25% faster)
* `uniform_sleep_of_10ms`
  * 81.59 rounds/sec (256% faster)
* `exporter_10ms_while_others_1ms`
  * 81.23 rounds/sec (26% faster)
* `importer_10ms_while_others_1ms`
  * 91.97 rounds/sec (44% faster)
* `first_processor_10ms_while_others_1ms`
  * 90.84 rounds/sec (46% faster)

### After the signals approach (with `concurrentRounds = 2`)

### statistics

* `vanilla_2_procs_without_sleep`
  * 3257 rounds/sec (3% faster)
* `uniform_sleep_of_10ms`
  * 43.25 rounds/sec (89% faster)
* `exporter_10ms_while_others_1ms`
  * 82.32 rounds/sec (28% faster)
* `importer_10ms_while_others_1ms`
  * 119.2 rounds/sec (86% faster)
* `first_processor_10ms_while_others_1ms`
  * 120.0 rounds/sec (92% faster)

### After the signals approach (with `concurrentRounds = 3`)

### statistics

* `vanilla_2_procs_without_sleep`
  * 3828 rounds/sec (21% faster)
* `uniform_sleep_of_10ms`
  * 65.27 rounds/sec (185% faster)
* `exporter_10ms_while_others_1ms`
  * 81.17 rounds/sec (26% faster)
* `importer_10ms_while_others_1ms`
  * 187.4 rounds/sec (193% faster)
* `first_processor_10ms_while_others_1ms`
  * 193.4 rounds/sec (210% faster)

### After the signals approach (with `concurrentRounds = 10`)

### statistics

* `vanilla_2_procs_without_sleep`
  * 3855 rounds/sec (22% faster)
* `uniform_sleep_of_10ms`
  *  82.40 rounds/sec (259% faster)
* `exporter_10ms_while_others_1ms`
  * 81.14 rounds/sec (26% faster)
* `importer_10ms_while_others_1ms`
  * 627.1 rounds/sec (880% faster)
* `first_processor_10ms_while_others_1ms`
  * 541.2 rounds/sec (768% faster)

## Approach outlined by Will after design discussion

* `vanilla_2_procs_without_sleep`
  * 3038 rounds/sec (4% _SLOWER_)
* `uniform_sleep_of_10ms`
  *  83.20 rounds/sec (263% faster)
* `exporter_10ms_while_others_1ms`
  * 83.08 rounds/sec (29% faster)
* `importer_10ms_while_others_1ms`
  * 92.44 rounds/sec (44% faster)
* `first_processor_10ms_while_others_1ms`
  * 92.51 rounds/sec (48% faster)