### PR TITLE
chore: update deprecated goreleaser option.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -76,11 +76,15 @@ docker_manifests:
     - "{{ .Env.DOCKER_NAME }}:latest{{ if .IsSnapshot }}-snapshot{{ end }}-arm64"
 
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else if eq .Arch "windows" }}Windows
+      {{- else if eq .Arch "linux" }}Linux
+      {{- else if eq .Arch "darwin" }}Darwin
+      {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
## Summary

Replaces the deprecated replacements option according to recommendation in docs: https://goreleaser.com/deprecations/#archivesreplacements
