### PR TITLE
algod importer: Update sync on WaitForBlock error.

### DIFF
--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -414,6 +414,7 @@ func (algodImp *algodImporter) getDelta(rnd uint64) (sdk.LedgerStateDelta, error
 	return delta, nil
 }
 
+// SyncError is used to indicate algod and conduit are not synchronized.
 type SyncError struct {
 	rnd      uint64
 	expected uint64

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -461,7 +461,7 @@ func waitForRoundWithTimeout(ctx context.Context, l *logrus.Logger, c *algod.Cli
 	}
 
 	// This is probably a connection error, not a SyncError.
-	return 0, fmt.Errorf("unknown error: %w", errors.Join(err, err2))
+	return 0, fmt.Errorf("unknown errors: StatusAfterBlock(%w), Status(%w)", err, err2)
 }
 
 func (algodImp *algodImporter) getBlockInner(rnd uint64) (data.BlockData, error) {

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -680,7 +680,7 @@ func TestGetBlockErrors(t *testing.T) {
 		{
 			name:                "Cannot wait for block",
 			rnd:                 123,
-			blockAfterResponder: MakeJsonResponderSeries("/wait-for-block-after", []int{http.StatusOK, http.StatusNotFound}, []interface{}{models.NodeStatus{}}),
+			blockAfterResponder: MakeJsonResponderSeries("/wait-for-block-after", []int{http.StatusOK, http.StatusNotFound}, []interface{}{models.NodeStatus{LastRound: 1}}),
 			err:                 fmt.Sprintf("error getting block for round 123"),
 			logs:                []string{"error getting block for round 123"},
 		},
@@ -755,9 +755,7 @@ func TestGetBlockErrors(t *testing.T) {
 			// Make sure each of the expected log messages are present
 			for _, log := range tc.logs {
 				found := false
-				fmt.Printf("Looking for: %s\n", log)
 				for _, entry := range hook.AllEntries() {
-					fmt.Printf(" * %s\n", entry.Message)
 					fmt.Println(strings.Contains(entry.Message, log))
 					found = found || strings.Contains(entry.Message, log)
 				}

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -644,48 +644,40 @@ func TestGetBlockErrors(t *testing.T) {
 		logs                []string
 		err                 string
 	}{
-		/*
-			{
-				name:                "Cannot wait for block",
-				rnd:                 123,
-				blockAfterResponder: MakeJsonResponderSeries("/wait-for-block-after", []int{http.StatusNotFound}, []interface{}{models.NodeStatus{}}),
-				// Skip over the "needs catchup" logic.
-				blockResponder: MakeMsgpStatusResponder("get", "/v2/blocks/", http.StatusOK, sdk.LedgerStateDelta{}),
-				deltaResponder: MakeMsgpStatusResponder("get", "/v2/deltas/", http.StatusOK, sdk.LedgerStateDelta{}),
-				err:            fmt.Sprintf("error getting block for round 123"),
-				logs:           []string{"error getting block for round 123"},
-			},
-		*/
+		{
+			name:                "Cannot wait for block",
+			rnd:                 123,
+			blockAfterResponder: MakeJsonResponderSeries("/wait-for-block-after", []int{http.StatusOK, http.StatusNotFound}, []interface{}{models.NodeStatus{}}),
+			err:                 fmt.Sprintf("error getting block for round 123"),
+			logs:                []string{"error getting block for round 123"},
+		},
 		{
 			name:                "Cannot get block",
 			rnd:                 123,
 			blockAfterResponder: BlockAfterResponder,
 			deltaResponder:      MakeMsgpStatusResponder("get", "/v2/deltas/", http.StatusNotFound, sdk.LedgerStateDelta{}),
 			blockResponder:      MakeMsgpStatusResponder("get", "/v2/blocks/", http.StatusNotFound, ""),
-			err:                 fmt.Sprintf("failed to get block"),
-			logs:                []string{"error getting block for round 123", "failed to get block for round 123 "},
+			err:                 fmt.Sprintf("error getting block for round 123"),
+			logs:                []string{"error getting block for round 123"},
 		},
-		/*
-			{
-				name:                "Cannot get delta (node behind)",
-				rnd:                 200,
-				blockAfterResponder: MakeBlockAfterResponder(models.NodeStatus{LastRound: 50}),
-				blockResponder:      BlockResponder,
-				deltaResponder:      MakeMsgpStatusResponder("get", "/v2/deltas/", http.StatusNotFound, ""),
-				err:                 fmt.Sprintf("ledger state delta not found: node round (50) is behind required round (200)"),
-				logs:                []string{"ledger state delta not found: node round (50) is behind required round (200)"},
-			},
-			{
-				name:                "Cannot get delta (caught up)",
-				rnd:                 200,
-				blockAfterResponder: MakeBlockAfterResponder(models.NodeStatus{LastRound: 200}),
-				blockResponder:      BlockResponder,
-				deltaResponder:      MakeMsgpStatusResponder("get", "/v2/deltas/", http.StatusNotFound, ""),
-				err:                 fmt.Sprintf("ledger state delta not found: node round (200), required round (200)"),
-				logs:                []string{"ledger state delta not found: node round (200), required round (200)"},
-			},
-
-		*/
+		{
+			name:                "Cannot get delta (node behind)",
+			rnd:                 200,
+			blockAfterResponder: MakeBlockAfterResponder(models.NodeStatus{LastRound: 50}),
+			blockResponder:      BlockResponder,
+			deltaResponder:      MakeMsgpStatusResponder("get", "/v2/deltas/", http.StatusNotFound, ""),
+			err:                 fmt.Sprintf("wrong round returned from status for round: 50 != 200"),
+			logs:                []string{"wrong round returned from status for round: 50 != 200", "Sync error detected, attempting to set the sync round to recover the node"},
+		},
+		{
+			name:                "Cannot get delta (caught up)",
+			rnd:                 200,
+			blockAfterResponder: MakeBlockAfterResponder(models.NodeStatus{LastRound: 200}),
+			blockResponder:      BlockResponder,
+			deltaResponder:      MakeMsgpStatusResponder("get", "/v2/deltas/", http.StatusNotFound, ""),
+			err:                 fmt.Sprintf("ledger state delta not found: node round (200), required round (200)"),
+			logs:                []string{"ledger state delta not found: node round (200), required round (200)"},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -581,6 +581,10 @@ netaddr: %s
 }
 
 func TestGetBlockFailure(t *testing.T) {
+	// Note: There are panics in the log because the init function in these tests calls the
+	//       delta endpoint and causes a panic in most cases. This causes the "needs catchup"
+	//       function to send out a sync request at which point logic continues as normal and
+	//       the GetBlock function is able to run for the test.
 	tests := []struct {
 		name        string
 		algodServer *httptest.Server

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -661,7 +661,7 @@ func TestGetBlockErrors(t *testing.T) {
 			logs:                []string{"error getting block for round 123"},
 		},
 		{
-			name:                "Cannot get delta (node behind)",
+			name:                "Cannot get delta (node behind, re-send sync)",
 			rnd:                 200,
 			blockAfterResponder: MakeBlockAfterResponder(models.NodeStatus{LastRound: 50}),
 			blockResponder:      BlockResponder,

--- a/conduit/plugins/importers/algod/mock_algod_test.go
+++ b/conduit/plugins/importers/algod/mock_algod_test.go
@@ -107,7 +107,17 @@ func MakeNodeStatusResponder(status models.NodeStatus) algodCustomHandler {
 	return MakeJsonResponder("/v2/status", status)
 }
 
-var BlockAfterResponder = MakeBlockAfterResponder(models.NodeStatus{})
+// BlockAfterResponder handles /v2/status requests and returns a NodeStatus object with the provided last round
+func BlockAfterResponder(r *http.Request, w http.ResponseWriter) bool {
+	if strings.Contains(r.URL.Path, "/wait-for-block-after") {
+		rnd, _ := strconv.Atoi(path.Base(r.URL.Path))
+		w.WriteHeader(http.StatusOK)
+		status := models.NodeStatus{LastRound: uint64(rnd + 1)}
+		_, _ = w.Write(json.Encode(status))
+		return true
+	}
+	return false
+}
 
 func MakeLedgerStateDeltaResponder(delta types.LedgerStateDelta) algodCustomHandler {
 	return MakeMsgpResponder("/v2/deltas/", delta)


### PR DESCRIPTION
## Summary

If algod is restarted after it receives a sync round update but before it fetches the new round(s), then the algod follower and conduit will stall. Conduit will keep waiting for algod to reach the new sync round but it never happens.

This change adds some extra logic to the `WaitForBlock` call. If there is a timeout or a bad response, a new attempt to set the sync round is made.

This PR also removes the retry loop from the algod importer. Retry is now managed by the pipeline.
 
## Test Plan

Update existing unit tests.