### PR TITLE
Default to retrying after errors forever.

### DIFF
--- a/pkg/cli/internal/initialize/conduit.yml.example
+++ b/pkg/cli/internal/initialize/conduit.yml.example
@@ -6,7 +6,7 @@ log-level: INFO
 
 # Number of retries to perform after a pipeline plugin error.
 # Set to 0 to retry forever.
-retry-count: 10
+retry-count: 0
 
 # Time duration to wait between retry attempts.
 retry-delay: "1s"


### PR DESCRIPTION
## Summary

On an errors, Indexer will retry forever. Users have expressed an appreciation for this behavior because they can perform maintenance on algod and it doesn't disrupt service on the downstream applications.

This changes Conduit's default retry on error behavior to have unlimited attempts, which matches how Indexer 2.x works.
