### PR TITLE
more granular timestamps in logs

### DIFF
--- a/conduit/data/config.go
+++ b/conduit/data/config.go
@@ -10,6 +10,17 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
+const (
+	// ConduitTimeFormat is the time format used by conduit's logger.
+	// time.RFC3339Nano = "2006-01-02T15:04:05.999999999Z07:00"
+	// Compare with logrus' default time format:
+	// time.RFC1123Z = "Mon, 02 Jan 2006 15:04:05 -0700"
+	ConduitTimeFormat = time.RFC3339Nano
+
+	// Unfortunately, variations on this theme didn't work:
+	// ConduitTimeFormat = "Mon, 02 Jan 2006 15:04:05.123456789 -0700"
+)
+
 // DefaultConfigBaseName is the default conduit configuration filename without the extension.
 var DefaultConfigBaseName = "conduit"
 

--- a/conduit/data/config.go
+++ b/conduit/data/config.go
@@ -13,8 +13,6 @@ import (
 const (
 	// ConduitTimeFormat is the time format used by conduit's logger.
 	// time.RFC3339Nano = "2006-01-02T15:04:05.999999999Z07:00"
-	// Compare with logrus' default time format:
-	// time.RFC1123Z = "Mon, 02 Jan 2006 15:04:05 -0700"
 	ConduitTimeFormat = time.RFC3339Nano
 )
 

--- a/conduit/data/config.go
+++ b/conduit/data/config.go
@@ -16,9 +16,6 @@ const (
 	// Compare with logrus' default time format:
 	// time.RFC1123Z = "Mon, 02 Jan 2006 15:04:05 -0700"
 	ConduitTimeFormat = time.RFC3339Nano
-
-	// Unfortunately, variations on this theme didn't work:
-	// ConduitTimeFormat = "Mon, 02 Jan 2006 15:04:05.123456789 -0700"
 )
 
 // DefaultConfigBaseName is the default conduit configuration filename without the extension.

--- a/conduit/loggers/loggers.go
+++ b/conduit/loggers/loggers.go
@@ -8,6 +8,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/algorand/conduit/conduit/data"
 	"github.com/algorand/conduit/conduit/pipeline"
 )
 
@@ -16,6 +17,7 @@ func MakeThreadSafeLoggerWithWriter(level log.Level, writer io.Writer) *log.Logg
 	formatter := pipeline.PluginLogFormatter{
 		Formatter: &log.JSONFormatter{
 			DisableHTMLEscape: true,
+			TimestampFormat:   data.ConduitTimeFormat,
 		},
 		Type: "Conduit",
 		Name: "main",

--- a/conduit/pipeline/logging.go
+++ b/conduit/pipeline/logging.go
@@ -2,6 +2,8 @@ package pipeline
 
 import (
 	log "github.com/sirupsen/logrus"
+
+	"github.com/algorand/conduit/conduit/data"
 )
 
 // PluginLogFormatter formats the log message with special conduit tags
@@ -23,6 +25,7 @@ func makePluginLogFormatter(pluginType string, pluginName string) PluginLogForma
 	return PluginLogFormatter{
 		Formatter: &log.JSONFormatter{
 			DisableHTMLEscape: true,
+			TimestampFormat:   data.ConduitTimeFormat,
 		},
 		Type: pluginType,
 		Name: pluginName,

--- a/conduit/pipeline/logging_test.go
+++ b/conduit/pipeline/logging_test.go
@@ -10,7 +10,6 @@ import (
 
 // TestPluginLogFormatter_Format tests the output of the formatter while pondering philosophy
 func TestPluginLogFormatter_Format(t *testing.T) {
-
 	pluginType := "A Question"
 	pluginName := "What's in a name?"
 
@@ -29,6 +28,8 @@ func TestPluginLogFormatter_Format(t *testing.T) {
 	bytes, err := pluginFormatter.Format(entry)
 	assert.Nil(t, err)
 	str := string(bytes)
-	assert.Equal(t, str, "{\"__type\":\"A Question\",\"_name\":\"What's in a name?\",\"level\":\"info\",\"msg\":\"That which we call a rose by any other name would smell just as sweet.\",\"time\":\"0001-01-01T00:00:00Z\"}\n")
-
+	assert.Equal(t,
+		"{\"__type\":\"A Question\",\"_name\":\"What's in a name?\",\"level\":\"info\",\"msg\":\"That which we call a rose by any other name would smell just as sweet.\",\"time\":\"0001-01-01T00:00:00Z\"}\n",
+		str,
+	)
 }


### PR DESCRIPTION
## Summary

Change Conduit's formatter for a higher level of granularity to:

```go
time.RFC3339Nano = "2006-01-02T15:04:05.999999999Z07:00"
```

## Caveat

> The RFC3339Nano format removes trailing zeros from the seconds field and thus may not sort correctly once formatted.

Taken from: https://pkg.go.dev/time



## Test Plan


CI