### PR TITLE
Algod Importer: Longer Timeout

### DIFF
--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -456,7 +456,8 @@ func waitForRoundWithTimeout(ctx context.Context, l *logrus.Logger, c *algod.Cli
 		if rnd <= status.LastRound {
 			return status.LastRound, nil
 		}
-		return 0, NewSyncError(status.LastRound, rnd, fmt.Errorf("this check should never be required: %w", err))
+		// algod's timeout should not be reached because context.WithTimeout is used
+		return 0, NewSyncError(status.LastRound, rnd, fmt.Errorf("sync error, likely due to status after block timeout: %w", err))
 	}
 
 	// If there was a different error and the node is responsive, call status before returning a SyncError.

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -42,7 +42,7 @@ const (
 )
 
 var (
-	waitForRoundTimeout = 15 * time.Second
+	waitForRoundTimeout = 30 * time.Second
 )
 
 const catchpointsURL = "https://algorand-catchpoints.s3.us-east-2.amazonaws.com/consolidated/%s_catchpoints.txt"

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -420,6 +420,7 @@ func (algodImp *algodImporter) getDelta(rnd uint64) (sdk.LedgerStateDelta, error
 // SyncError is used to indicate algod and conduit are not synchronized.
 // The retrievedRound is the round returned from an algod status call.
 // The expectedRound is the round conduit expected to have gotten back.
+// err is the error that was received from the endpoint caller
 type SyncError struct {
 	retrievedRound uint64
 	expectedRound  uint64

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -481,9 +481,7 @@ func (algodImp *algodImporter) getBlockInner(rnd uint64) (data.BlockData, error)
 
 	nodeRound, err := waitForRoundWithTimeout(algodImp.ctx, algodImp.logger, algodImp.aclient, rnd, waitForRoundTimeout)
 	if err != nil {
-		if algodImp.ctx.Err() != nil {
-			return blk, fmt.Errorf("importer algod.GetBlock() ctx cancelled: %w", err)
-		}
+		err = fmt.Errorf("err: %w, ctx cancellation: %w", err, algodImp.ctx.Err())
 		algodImp.logger.Errorf("importer algod.GetBlock() called waitForRoundWithTimeout: %v", err)
 		return data.BlockData{}, err
 	}

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -423,10 +423,10 @@ type SyncError struct {
 	retrievedRound uint64
 
 	// expectedRound is the round conduit expected to have gotten back.
-	expectedRound  uint64
+	expectedRound uint64
 
 	// err is the error that was received from the endpoint caller.
-	err            error
+	err error
 }
 
 // NewSyncError creates a new SyncError.

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -457,7 +457,7 @@ func waitForRoundWithTimeout(ctx context.Context, l *logrus.Logger, c *algod.Cli
 			return status.LastRound, nil
 		}
 		// algod's timeout should not be reached because context.WithTimeout is used
-		return 0, NewSyncError(status.LastRound, rnd, fmt.Errorf("sync error, likely due to status after block timeout: %w", err))
+		return 0, NewSyncError(status.LastRound, rnd, fmt.Errorf("sync error, likely due to status after block timeout"))
 	}
 
 	// If there was a different error and the node is responsive, call status before returning a SyncError.

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -418,12 +418,14 @@ func (algodImp *algodImporter) getDelta(rnd uint64) (sdk.LedgerStateDelta, error
 }
 
 // SyncError is used to indicate algod and conduit are not synchronized.
-// The retrievedRound is the round returned from an algod status call.
-// The expectedRound is the round conduit expected to have gotten back.
-// err is the error that was received from the endpoint caller.
 type SyncError struct {
+	// retrievedRound is the round returned from an algod status call.
 	retrievedRound uint64
+
+	// expectedRound is the round conduit expected to have gotten back.
 	expectedRound  uint64
+
+	// err is the error that was received from the endpoint caller.
 	err            error
 }
 

--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -420,7 +420,7 @@ func (algodImp *algodImporter) getDelta(rnd uint64) (sdk.LedgerStateDelta, error
 // SyncError is used to indicate algod and conduit are not synchronized.
 // The retrievedRound is the round returned from an algod status call.
 // The expectedRound is the round conduit expected to have gotten back.
-// err is the error that was received from the endpoint caller
+// err is the error that was received from the endpoint caller.
 type SyncError struct {
 	retrievedRound uint64
 	expectedRound  uint64

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -766,7 +766,7 @@ func TestGetBlockErrors(t *testing.T) {
 				for _, entry := range hookEntries {
 					logIsSubstring := strings.Contains(entry.Message, log)
 					found = found || logIsSubstring
-					fmt.Printf("expectedMessageInLog=%t, found=%t:\n\t%s\n", logIsSubstring, found, entry.Message)
+					fmt.Printf("logIsSubstring=%t, found=%t:\n\t%s\n", logIsSubstring, found, entry.Message)
 				}
 				noError = noError && assert.True(t, found, "(%s) Expected log was not found: '%s'", tc.name, log)
 				if !noError {

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -682,7 +682,7 @@ func TestGetBlockErrors(t *testing.T) {
 			name:                "Cannot wait for block",
 			rnd:                 123,
 			blockAfterResponder: MakeJsonResponderSeries("/wait-for-block-after", []int{http.StatusOK, http.StatusNotFound}, []interface{}{models.NodeStatus{LastRound: 1}}),
-			err:                 fmt.Sprintf("error getting block for round 123"),
+			err:                 "error getting block for round 123",
 			logs:                []string{"error getting block for round 123"},
 		},
 		{
@@ -691,7 +691,7 @@ func TestGetBlockErrors(t *testing.T) {
 			blockAfterResponder: BlockAfterResponder,
 			deltaResponder:      MakeMsgpStatusResponder("get", "/v2/deltas/", http.StatusNotFound, sdk.LedgerStateDelta{}),
 			blockResponder:      MakeMsgpStatusResponder("get", "/v2/blocks/", http.StatusNotFound, ""),
-			err:                 fmt.Sprintf("error getting block for round 123"),
+			err:                 "error getting block for round 123",
 			logs:                []string{"error getting block for round 123"},
 		},
 		{
@@ -700,7 +700,7 @@ func TestGetBlockErrors(t *testing.T) {
 			blockAfterResponder: MakeBlockAfterResponder(models.NodeStatus{LastRound: 50}),
 			blockResponder:      BlockResponder,
 			deltaResponder:      MakeMsgpStatusResponder("get", "/v2/deltas/", http.StatusNotFound, ""),
-			err:                 fmt.Sprintf("wrong round returned from status for round: retrieved(50) != expected(200)"),
+			err:                 "wrong round returned from status for round: retrieved(50) != expected(200)",
 			logs:                []string{"wrong round returned from status for round: retrieved(50) != expected(200)", "sync error detected, attempting to set the sync round to recover the node"},
 		},
 		{
@@ -709,7 +709,7 @@ func TestGetBlockErrors(t *testing.T) {
 			blockAfterResponder: MakeBlockAfterResponder(models.NodeStatus{LastRound: 200}),
 			blockResponder:      BlockResponder,
 			deltaResponder:      MakeMsgpStatusResponder("get", "/v2/deltas/", http.StatusNotFound, ""),
-			err:                 fmt.Sprintf("ledger state delta not found: node round (200), required round (200)"),
+			err:                 "ledger state delta not found: node round (200), required round (200)",
 			logs:                []string{"ledger state delta not found: node round (200), required round (200)"},
 		},
 	}

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -3,16 +3,17 @@ package algodimporter
 import (
 	"context"
 	"fmt"
-	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v3"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 
 	"github.com/algorand/go-algorand-sdk/v2/client/v2/algod"
 	"github.com/algorand/go-algorand-sdk/v2/client/v2/common/models"
@@ -699,8 +700,8 @@ func TestGetBlockErrors(t *testing.T) {
 			blockAfterResponder: MakeBlockAfterResponder(models.NodeStatus{LastRound: 50}),
 			blockResponder:      BlockResponder,
 			deltaResponder:      MakeMsgpStatusResponder("get", "/v2/deltas/", http.StatusNotFound, ""),
-			err:                 fmt.Sprintf("wrong round returned from status for round: 50 != 200"),
-			logs:                []string{"wrong round returned from status for round: 50 != 200", "Sync error detected, attempting to set the sync round to recover the node"},
+			err:                 fmt.Sprintf("wrong round returned from status for round: retrieved(50) != expected(200)"),
+			logs:                []string{"wrong round returned from status for round: retrieved(50) != expected(200)", "sync error detected, attempting to set the sync round to recover the node"},
 		},
 		{
 			name:                "Cannot get delta (caught up)",
@@ -755,7 +756,8 @@ func TestGetBlockErrors(t *testing.T) {
 			// Make sure each of the expected log messages are present
 			for _, log := range tc.logs {
 				found := false
-				for _, entry := range hook.AllEntries() {
+				hookEntries := hook.AllEntries()
+				for _, entry := range hookEntries {
 					fmt.Println(strings.Contains(entry.Message, log))
 					found = found || strings.Contains(entry.Message, log)
 				}

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -762,16 +762,15 @@ func TestGetBlockErrors(t *testing.T) {
 			hookEntries := hook.AllEntries()
 			for _, log := range tc.logs {
 				found := false
-				fmt.Println("~~~\nCurrent log: ", log)
 				for _, entry := range hookEntries {
 					logIsSubstring := strings.Contains(entry.Message, log)
 					found = found || logIsSubstring
 					fmt.Printf("logIsSubstring=%t, found=%t:\n\t%s\n", logIsSubstring, found, entry.Message)
 				}
-				noError = noError && assert.True(t, found, "(%s) Expected log was not found: '%s'", tc.name, log)
-				if !noError {
-					fmt.Printf(">>>>>WE HAVE A PROBLEM<<<<<<\n")
+				if !found {
+					fmt.Printf(">>>>>>WE HAVE A PROBLEM<<<<<<\n")
 				}
+				noError = noError && assert.True(t, found, "(%s) Expected log was not found: '%s'", tc.name, log)
 			}
 
 			// Print logs if there was an error.

--- a/conduit/plugins/importers/algod/mock_algod_test.go
+++ b/conduit/plugins/importers/algod/mock_algod_test.go
@@ -33,7 +33,11 @@ func NewAlgodHandler(responders ...algodCustomHandler) *AlgodHandler {
 
 // ServeHTTP implements the http.Handler interface for AlgodHandler
 func (handler *AlgodHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	for _, responder := range handler.responders {
+	for i, responder := range handler.responders {
+		_ = i
+		if responder == nil {
+			continue
+		}
 		if responder(req, w) {
 			return
 		}


### PR DESCRIPTION
# Change `waitForRoundTimeout` to 30 from 5

1. changing the amount of time to wait for the next round
2. adding more context to the `SyncError` type

## Explanation for the timeout change

During a recent EC2 import test, I noticed that after catching up, around 1% of imports are reporting an error/warning:

```json
{
"__type":"importer",
"_name":"algod",
"level":"warning",
"msg":"Sync error detected, attempting to set the sync round to recover the node: wrong round returned from status for round: 0 != 31117945",
"time":"2023-08-07T15:31:16.166545875Z"
}
{
"__type":"Conduit",
"_name":"main",
"level":"error",
"msg":"wrong round returned from status for round: 0 != 31117945",
"time":"2023-08-07T15:31:16.166783576Z"
}
```

The `pipelining` branch, which added some more information to the `SyncError` errored similarly with the warning msg:
```txt
importer algod.GetBlock() sync error detected, attempting to set the sync round to recover the node: wrong round returned from status for round: 31112472 != 31112473: status2.LastRound mismatch: context deadline exceeded
```

So we can see that we're getting a timeout error. This is to be expected _on occasion_ as when calling algod's `StatusAfterBlock()`, a [context is provided](https://github.com/tzaffi/conduit/blob/1f7f332208a2c815db352bd69ffb15bc380399fc/conduit/plugins/importers/algod/algod_importer.go#L447) with a 5 sec timeout.

Having carried out some [statistical analysis](https://gist.github.com/tzaffi/3c3d25b7e30e5b53e6d5d5772736faf6#file-round_time_stats-sql) on the last 1 million rounds, I got the following results:

| mean_duration | stdev_duration | min_duration | max_duration | 0-4    | 5-9  | 10-14 | 15-19 | 20-24 |
|---------------------|----------------------|-------------------|--------------------|--------|------|-------|-------|-------|
| 3.400925599   | 0.507927656    | 0            | 22           | 999803 | 148  | 0     | 0     | 50    |

So if we re-set `waitForRoundTimeout = 30`, we're likely to encounter 0 such timeouts, or at most a small number.

On the other hand, algod's own timeout is [60 secs](https://github.com/algorand/go-algorand/blob/5d5ca32d517a4b88767add3189a4199d1fe1b9e0/daemon/algod/api/server/v2/handlers.go#L70) so we are steering quite far from the upper bound.