### PR TITLE
Remove quotes in file_write examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ importer:
 processors:
 
 exporter:
-    name: "file_writer"
+    name: file_writer
     config:
         # the default config writes block data to the data directory.
 ```

--- a/conduit/plugins/exporters/filewriter/README.md
+++ b/conduit/plugins/exporters/filewriter/README.md
@@ -4,7 +4,7 @@ Write block data to files. This plugin works with the file rerader plugin to cre
 
 ## Configuration
 ```yml @sample.yaml
-name: "file_writer"
+name: file_writer
 config:
     # BlocksDir is the path to a directory where block data should be stored.
     # The directory is created if it doesn't exist. If no directory is provided

--- a/conduit/plugins/exporters/filewriter/sample.yaml
+++ b/conduit/plugins/exporters/filewriter/sample.yaml
@@ -1,4 +1,4 @@
-name: "file_writer"
+name: file_writer
 config:
     # BlocksDir is the path to a directory where block data should be stored.
     # The directory is created if it doesn't exist. If no directory is provided


### PR DESCRIPTION
## Summary

Remove quotes to make the documentation more consistent.
## Test Plan

N/A