### PR TITLE
build: add version to release filename.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -81,7 +81,8 @@ archives:
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
+      {{- else }}{{ .Arch }}{{ end }}_
+      {{- .Version }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
## Summary

Add the version to release filenames to be closer to the pattern used by algod.

conduit_Darwin_all_1.3.1.tar.gz
conduit_Linux_arm64_1.3.1.tar.gz
conduit_Linux_x86_64_1.3.1.tar.gz
conduit_Windows_arm64_1.3.1.tar.gz
conduit_Windows_x86_64_1.3.1.tar.gz

## Test Plan

Run goreleaser locally.
