### PR TITLE
Add credentials for telemetry

### DIFF
--- a/pkg/cli/internal/initialize/conduit.test.init.default.yml
+++ b/pkg/cli/internal/initialize/conduit.test.init.default.yml
@@ -7,6 +7,17 @@ metrics:
   addr: ":9999"
   prefix: "conduit"
 
+# Enable telemetry for conduit
+telemetry:
+  enabled: false
+  
+  # By default the following fields will be configured to send data to Algorand.
+  # To store your own telemetry events, they can be overridden.
+  # uri: "https://conduit-telemetry.deveks.algodev.network"
+  # index: "conduit-telemetry-testing"
+  # username: "conduit-telemetry"
+  # password: "ratchet-tahiti-hunker-plebs-hamburg-wiretap-aplomb-mongoose-roomful"
+
 # The importer is typically an algod archival instance.
 importer:
   name: algod
@@ -35,14 +46,3 @@ exporter:
     filename-pattern: "%[1]d_block.json"
     # DropCertificate is used to remove the vote certificate from the block data before writing files.
     drop-certificate: true
-
-# Enable telemetry for conduit
-telemetry:
-  enabled: false
-  
-  # By default the following fields will be configured to send data to Algorand.
-  # To store your own telemetry events, they can be overridden.
-  # uri: "https://conduit-telemetry.deveks.algodev.network"
-  # index: "conduit-telemetry-testing"
-  # username: "conduit-telemetry"
-  # password: "ratchet-tahiti-hunker-plebs-hamburg-wiretap-aplomb-mongoose-roomful"

--- a/pkg/cli/internal/initialize/conduit.test.init.default.yml
+++ b/pkg/cli/internal/initialize/conduit.test.init.default.yml
@@ -42,7 +42,7 @@ telemetry:
   
   # By default the following fields will be configured to send data to Algorand.
   # To store your own telemetry events, they can be overridden.
-  # uri: ""
-  # index: ""
-  # username: ""
-  # password: ""
+  # uri: "https://conduit-telemetry.deveks.algodev.network"
+  # index: "conduit-telemetry-testing"
+  # username: "conduit-telemetry"
+  # password: "ratchet-tahiti-hunker-plebs-hamburg-wiretap-aplomb-mongoose-roomful"

--- a/pkg/cli/internal/initialize/conduit.yml.example
+++ b/pkg/cli/internal/initialize/conduit.yml.example
@@ -37,3 +37,28 @@ processors:
 # An exporter is defined to do something with the data.
 exporter:
 %s
+<<<<<<< Updated upstream
+=======
+
+# Enable telemetry for conduit
+telemetry:
+<<<<<<< Updated upstream
+  enabled: false
+
+  # By default the following fields will be configured to send data to Algorand.
+  # To store your own telemetry events, they can be overridden.
+  # uri: ""
+  # index: ""
+  # username: ""
+  # password: ""
+=======
+    enabled: false
+
+    # By default the following fields will be configured to send data to Algorand.
+    # To store your own telemetry events, they can be overridden.
+    # uri: "https://conduit-telemetry.deveks.algodev.network"
+    # index: "conduit-telemetry-testing"
+    # username: "conduit-telemetry"
+    # password: "ratchet-tahiti-hunker-plebs-hamburg-wiretap-aplomb-mongoose-roomful"
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes

--- a/pkg/cli/internal/initialize/conduit.yml.example
+++ b/pkg/cli/internal/initialize/conduit.yml.example
@@ -37,8 +37,6 @@ processors:
 # An exporter is defined to do something with the data.
 exporter:
 %s
-<<<<<<< Updated upstream
-=======
 
 # Enable telemetry for conduit
 telemetry:

--- a/pkg/cli/internal/initialize/conduit.yml.example
+++ b/pkg/cli/internal/initialize/conduit.yml.example
@@ -42,16 +42,6 @@ exporter:
 
 # Enable telemetry for conduit
 telemetry:
-<<<<<<< Updated upstream
-  enabled: false
-
-  # By default the following fields will be configured to send data to Algorand.
-  # To store your own telemetry events, they can be overridden.
-  # uri: ""
-  # index: ""
-  # username: ""
-  # password: ""
-=======
     enabled: false
 
     # By default the following fields will be configured to send data to Algorand.
@@ -60,5 +50,3 @@ telemetry:
     # index: "conduit-telemetry-testing"
     # username: "conduit-telemetry"
     # password: "ratchet-tahiti-hunker-plebs-hamburg-wiretap-aplomb-mongoose-roomful"
->>>>>>> Stashed changes
->>>>>>> Stashed changes

--- a/pkg/cli/internal/initialize/conduit.yml.example
+++ b/pkg/cli/internal/initialize/conduit.yml.example
@@ -27,17 +27,6 @@ metrics:
     addr: ":9999"
     prefix: "conduit"
 
-# The importer is typically an algod follower node.
-importer:
-%s
-# Zero or more processors may be defined to manipulate what data
-# reaches the exporter.
-processors:
-%s
-# An exporter is defined to do something with the data.
-exporter:
-%s
-
 # Enable telemetry for conduit
 telemetry:
     enabled: false
@@ -48,3 +37,14 @@ telemetry:
     # index: "conduit-telemetry-testing"
     # username: "conduit-telemetry"
     # password: "ratchet-tahiti-hunker-plebs-hamburg-wiretap-aplomb-mongoose-roomful"
+
+# The importer is typically an algod follower node.
+importer:
+%s
+# Zero or more processors may be defined to manipulate what data
+# reaches the exporter.
+processors:
+%s
+# An exporter is defined to do something with the data.
+exporter:
+%s


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Adds telemetry credentials for our Opensearch dev cluster.

## Test Plan

Push telemetry events on startup on local conduit instance.
