### PR TITLE
ci: Add gpg signature to checksum file.

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -36,6 +36,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+
       - uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
@@ -43,3 +50,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -95,6 +95,9 @@ changelog:
       - '^docs:'
       - '^test:'
 
+signs:
+  - artifacts: checksum
+
 release:
   draft: true
   header: |


### PR DESCRIPTION
## Summary

Sign checksum file as part of publishing a release.

The approach here follows a suggestion in the goreleaser docs where the signature is limited to the checksum file.

References:
* goreleaser docs: https://goreleaser.com/customization/sign/
* ghaction-import-gpg docs: https://github.com/crazy-max/ghaction-import-gpg

Repository configuration requires adding the GPG secret and passphrase.

## Test Plan

Tested the configuration in a private repo:
https://github.com/algorand/goreleaser-test/releases/tag/untagged-e548c44def7b11988fec