### PR TITLE
Set conduit data dir through env var

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -12,7 +12,7 @@ fi
 
 # copy config.yml override to data directory
 if [[ -f /etc/algorand/conduit.yml ]]; then
-  cp /etc/algorand/conduit.yml /data/conduit.yml
+  cp /etc/algorand/conduit.yml $CONDUIT_DATA_DIR/conduit.yml
 fi
 
 # always run the conduit command


### PR DESCRIPTION
Use `CONDUIT_DATA_DIR` in the entrypoint script for docker.
