### PR TITLE
Consensus: v39 protocol support via go-algorand-sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/algorand/conduit
 go 1.20
 
 require (
-	github.com/algorand/go-algorand-sdk/v2 v2.2.0
+	github.com/algorand/go-algorand-sdk/v2 v2.4.0
 	github.com/algorand/go-codec/codec v1.1.10
 	github.com/algorand/indexer/v3 v3.0.0
 	github.com/google/uuid v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/algorand/go-algorand-sdk/v2 v2.4.0
 	github.com/algorand/go-codec/codec v1.1.10
-	github.com/algorand/indexer/v3 v3.0.0
+	github.com/algorand/indexer/v3 v3.3.1-0.20231215213915-9ef21ad4c44f
 	github.com/google/uuid v1.3.0
 	github.com/jackc/pgx/v4 v4.13.0
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/algorand/avm-abi v0.2.0 h1:bkjsG+BOEcxUcnGSALLosmltE0JZdg+ZisXKx0UDX2k=
 github.com/algorand/avm-abi v0.2.0/go.mod h1:+CgwM46dithy850bpTeHh9MC99zpn2Snirb3QTl2O/g=
-github.com/algorand/go-algorand-sdk/v2 v2.2.0 h1:zWwK+k/WArtZJUSkDXTDj4a0GUik2iOhFlPjLFDET6s=
-github.com/algorand/go-algorand-sdk/v2 v2.2.0/go.mod h1:+3+4EZmMUcQk6bgmtC5Ic5kKZE/g6SmfiW098tYLkPE=
+github.com/algorand/go-algorand-sdk/v2 v2.4.0 h1:R9ykarfk0ojAZlXlrysViDwWjHrvUMA0HmFHg9PmECw=
+github.com/algorand/go-algorand-sdk/v2 v2.4.0/go.mod h1:Xk569fTpBTV0QtE74+79NTl6Rz3OC1K3iods4uG0ffU=
 github.com/algorand/go-codec/codec v1.1.10 h1:zmWYU1cp64jQVTOG8Tw8wa+k0VfwgXIPbnDfiVa+5QA=
 github.com/algorand/go-codec/codec v1.1.10/go.mod h1:YkEx5nmr/zuCeaDYOIhlDg92Lxju8tj2d2NrYqP7g7k=
 github.com/algorand/indexer/v3 v3.0.0 h1:FxQVt1KdwvJrKUAhJPeo+YAOygnJzgjKT8MUEawH+zc=

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/algorand/go-algorand-sdk/v2 v2.4.0 h1:R9ykarfk0ojAZlXlrysViDwWjHrvUMA
 github.com/algorand/go-algorand-sdk/v2 v2.4.0/go.mod h1:Xk569fTpBTV0QtE74+79NTl6Rz3OC1K3iods4uG0ffU=
 github.com/algorand/go-codec/codec v1.1.10 h1:zmWYU1cp64jQVTOG8Tw8wa+k0VfwgXIPbnDfiVa+5QA=
 github.com/algorand/go-codec/codec v1.1.10/go.mod h1:YkEx5nmr/zuCeaDYOIhlDg92Lxju8tj2d2NrYqP7g7k=
-github.com/algorand/indexer/v3 v3.0.0 h1:FxQVt1KdwvJrKUAhJPeo+YAOygnJzgjKT8MUEawH+zc=
-github.com/algorand/indexer/v3 v3.0.0/go.mod h1:P+RpgLu0lR/6RT8ZwspLHBNKVeAMzwRfCSMVsfiwf40=
+github.com/algorand/indexer/v3 v3.3.1-0.20231215213915-9ef21ad4c44f h1:obf3m/JnuCzCDLOHvGCo1oaAPSoW7RzSz8ehzFIlyyU=
+github.com/algorand/indexer/v3 v3.3.1-0.20231215213915-9ef21ad4c44f/go.mod h1:vGfnkuvXwv7iB3mros9enP5jbsqLsj3iYm7p46FhVXg=
 github.com/algorand/oapi-codegen v1.12.0-algorand.0 h1:W9PvED+wAJc+9EeXPONnA+0zE9UhynEqoDs4OgAxKhk=
 github.com/algorand/oapi-codegen v1.12.0-algorand.0/go.mod h1:tIWJ9K/qrLDVDt5A1p82UmxZIEGxv2X+uoujdhEAL48=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=


### PR DESCRIPTION
## Summary

Bump go-algorand-sdk dependency to v2.4.0 to support v39 consensus protocol.

## Test Plan

Existing tests should pass.
