### PR TITLE
Support to add custom consensus in conduit

### DIFF
--- a/conduit/pipeline/pipeline.go
+++ b/conduit/pipeline/pipeline.go
@@ -18,7 +18,8 @@ import (
 	yaml "gopkg.in/yaml.v3"
 
 	sdk "github.com/algorand/go-algorand-sdk/v2/types"
-
+	"github.com/algorand/go-algorand-sdk/v2/protocol/config"
+	
 	"github.com/algorand/conduit/conduit"
 	"github.com/algorand/conduit/conduit/data"
 	"github.com/algorand/conduit/conduit/metrics"
@@ -270,6 +271,14 @@ func (p *pipelineImpl) Init() error {
 			return err
 		}
 	}
+	
+	// Read custom consensus file for custom protocols
+        var consensus config.ConsensusProtocols
+        consensus , consensusErr := config.PreloadConfigurableConsensusProtocols(p.cfg.ConduitArgs.ConduitDataDir)
+        if consensusErr != nil {
+                return consensusErr
+        }
+        config.Consensus = consensus
 
 	// Read metadata file if it exists. We have to do this here in order to get
 	// the round from a previous run if it exists.


### PR DESCRIPTION
This is dependant on https://github.com/algorand/go-algorand-sdk/pull/625

## Summary

Conduit cannot process any blocks for algorand blockchains with custom consensus. This 5 line PR fixes it.

## Test Plan

I tested it manually on aramidmain blockchain.