### PR TITLE
Bump go version for workflows to 1.20.14

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install specific golang
         uses: actions/setup-go@v4.0.1
         with:
-          go-version: '1.20.5'
+          go-version: '1.20.14'
       - name: Check format
         run: test -z `go fmt ./...`
       - name: Vet
@@ -22,7 +22,7 @@ jobs:
         with:
           golangci_lint_version: "v1.53.2"
           golangci_lint_flags: "-c .golangci.yml --allow-parallel-runners"
-          go_version: "1.20.5"
+          go_version: "1.20.14"
           reporter: "github-pr-review"
           tool_name: "Lint Errors"
           level: "error"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Bump go version for workflows to 1.20.14.

## Test Plan

Existing tests and builds should succeed.
