### PR TITLE
Allow catchpoints from the exact target round

### DIFF
--- a/conduit/plugins/importers/algod/algod_importer.go
+++ b/conduit/plugins/importers/algod/algod_importer.go
@@ -186,8 +186,7 @@ func getMissingCatchpointLabel(URL string, nextRound uint64) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		// TODO: Change >= to > after go-algorand#5352 is fixed.
-		if uint64(round) >= nextRound {
+		if uint64(round) > nextRound {
 			break
 		}
 		label = line
@@ -204,8 +203,7 @@ func getMissingCatchpointLabel(URL string, nextRound uint64) (string, error) {
 // is detected.
 func checkRounds(logger *logrus.Logger, catchpointRound, nodeRound, targetRound uint64) (bool, error) {
 	// Make sure catchpoint round is not in the future
-	// TODO: Change < to <= after go-algorand#5352 is fixed.
-	canCatchup := catchpointRound < targetRound
+	canCatchup := catchpointRound <= targetRound
 	mustCatchup := targetRound < nodeRound
 	shouldCatchup := nodeRound < catchpointRound
 

--- a/conduit/plugins/importers/algod/algod_importer_test.go
+++ b/conduit/plugins/importers/algod/algod_importer_test.go
@@ -109,6 +109,18 @@ func Test_checkRounds(t *testing.T) {
 			wantLogMsg:   "Catchup required, node round ahead of target round. Node round 5000, target round 1002, catchpoint round 1000.",
 		},
 		{
+			name: "Catchup required. Success. Edgecase where catchpoint round is equal to target round.",
+			args: args{
+				catchpointRound: 1000,
+				nodeRound:       5000,
+				targetRound:     1000,
+			},
+			want:         true,
+			wantErr:      assert.NoError,
+			wantLogLevel: logrus.InfoLevel,
+			wantLogMsg:   "Catchup required, node round ahead of target round. Node round 5000, target round 1000, catchpoint round 1000.",
+		},
+		{
 			name: "Catchup required. Error.",
 			args: args{
 				catchpointRound: 6000,
@@ -130,8 +142,8 @@ func Test_checkRounds(t *testing.T) {
 
 			// Write 1 line to the log.
 			require.Len(t, hook.Entries, 1)
-			require.Equal(t, tt.wantLogLevel, hook.Entries[0].Level)
 			require.Equal(t, tt.wantLogMsg, hook.Entries[0].Message)
+			require.Equal(t, tt.wantLogLevel, hook.Entries[0].Level)
 
 			// Check the error
 			if !tt.wantErr(t, err, fmt.Sprintf("checkRounds(-, %v, %v, %v)", tt.args.catchpointRound, tt.args.nodeRound, tt.args.targetRound)) {
@@ -796,6 +808,11 @@ func TestGetMissingCatchpointLabel(t *testing.T) {
 	require.NoError(t, err)
 	// closest without going over
 	require.Equal(t, "1100#abcd", label)
+
+	label, err = getMissingCatchpointLabel(ts.URL, 1000)
+	require.NoError(t, err)
+	// returns the exact match
+	require.Equal(t, "1000#abcd", label)
 }
 
 func TestGetMissingCatchpointLabelError(t *testing.T) {


### PR DESCRIPTION
## Summary

https://github.com/algorand/go-algorand/issues/5352 has been fixed by https://github.com/algorand/go-algorand/pull/5798, and this PR undoes the workaround needed because of the original issue.

The original issue was that, if algod does fast catchup to round `X`, algod's REST API could not serve block `X`, since fast catchup did not also include block certificates. To work around this, conduit had to limit catchpoints to rounds `< X`, but now with this fixed in algod, the catchpoint round can be `<= X`.

## Test Plan

New unit test cases added
