### PR TITLE
Deps: Stable versions of go-algorand-sdk (v2.11.0) and indexer (v3.9.0).

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.23.0
 toolchain go1.23.3
 
 require (
-	github.com/algorand/go-algorand-sdk/v2 v2.10.1-0.20250829133552-9b5242cd2eb6
+	github.com/algorand/go-algorand-sdk/v2 v2.11.0
 	github.com/algorand/go-codec/codec v1.1.10
-	github.com/algorand/indexer/v3 v3.9.0-rc1
+	github.com/algorand/indexer/v3 v3.9.0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v4 v4.18.2
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -7,12 +7,12 @@ github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/algorand/avm-abi v0.2.0 h1:bkjsG+BOEcxUcnGSALLosmltE0JZdg+ZisXKx0UDX2k=
 github.com/algorand/avm-abi v0.2.0/go.mod h1:+CgwM46dithy850bpTeHh9MC99zpn2Snirb3QTl2O/g=
-github.com/algorand/go-algorand-sdk/v2 v2.10.1-0.20250829133552-9b5242cd2eb6 h1:F/n7SH3Jo4L1XGfJ/3gtSTaoo5h06YMyCvxbnKw3AQ4=
-github.com/algorand/go-algorand-sdk/v2 v2.10.1-0.20250829133552-9b5242cd2eb6/go.mod h1:D6iKT87/N6ajNpN7uMYPC9/RsOo2BbxnDfvh81E3hOM=
+github.com/algorand/go-algorand-sdk/v2 v2.11.0 h1:zE7BQZryEPdm1S+8+SOLGJubSYtfwOUO2nvJVakAF3s=
+github.com/algorand/go-algorand-sdk/v2 v2.11.0/go.mod h1:D6iKT87/N6ajNpN7uMYPC9/RsOo2BbxnDfvh81E3hOM=
 github.com/algorand/go-codec/codec v1.1.10 h1:zmWYU1cp64jQVTOG8Tw8wa+k0VfwgXIPbnDfiVa+5QA=
 github.com/algorand/go-codec/codec v1.1.10/go.mod h1:YkEx5nmr/zuCeaDYOIhlDg92Lxju8tj2d2NrYqP7g7k=
-github.com/algorand/indexer/v3 v3.9.0-rc1 h1:oifXfEDaeQWWPhvLOfWOTLzwYIc+xHRW9UaITWPBXYQ=
-github.com/algorand/indexer/v3 v3.9.0-rc1/go.mod h1:pD+GhLEOAOCymU+/QenCluS68MhjQix0V7n/EsoJK5Y=
+github.com/algorand/indexer/v3 v3.9.0 h1:wyVtM6QvIyYMcYIEmEA4LOAXMMEeGvaJXTLYP6Xd9k8=
+github.com/algorand/indexer/v3 v3.9.0/go.mod h1:/lbK/RTx18QMR9/U6D3p/Q8yc1XbG8R1YUfPwCxA7MA=
 github.com/algorand/oapi-codegen v1.12.0-algorand.0 h1:W9PvED+wAJc+9EeXPONnA+0zE9UhynEqoDs4OgAxKhk=
 github.com/algorand/oapi-codegen v1.12.0-algorand.0/go.mod h1:tIWJ9K/qrLDVDt5A1p82UmxZIEGxv2X+uoujdhEAL48=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate the time and effort you spent to get this far.

If you haven't already, please make sure that you've reviewed the CONTRIBUTING guide:
https://github.com/algorand/go-algorand/blob/master/CONTRIBUTING.md#code-guidelines
-->

## Summary

Stable versions of go-algorand-sdk (v2.11.0) and indexer (v3.9.0).

## Test Plan

Existing tests should pass.
