### PR TITLE
Bump go-algorand-sdk to include block Load (ld) field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.25.3
 
 require (
-	github.com/algorand/go-algorand-sdk/v2 v2.11.2-0.20251107185500-fe87fd072973
+	github.com/algorand/go-algorand-sdk/v2 v2.11.2-0.20260624180028-bfbd438b6ed3
 	github.com/algorand/go-codec/codec v1.1.10
 	github.com/algorand/indexer/v3 v3.9.1-0.20260112183408-2970dcb8ffa7
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/algorand/avm-abi v0.2.0 h1:bkjsG+BOEcxUcnGSALLosmltE0JZdg+ZisXKx0UDX2k=
 github.com/algorand/avm-abi v0.2.0/go.mod h1:+CgwM46dithy850bpTeHh9MC99zpn2Snirb3QTl2O/g=
-github.com/algorand/go-algorand-sdk/v2 v2.11.2-0.20251107185500-fe87fd072973 h1:6MPSCVuL7VfMsXD60W9zDrsozCruOw33FtTw++Mc1lU=
-github.com/algorand/go-algorand-sdk/v2 v2.11.2-0.20251107185500-fe87fd072973/go.mod h1:Q7M4OPLJcbL2gKxOg8xYEJ8tBwiplP+24huRbxg5Nus=
+github.com/algorand/go-algorand-sdk/v2 v2.11.2-0.20260624180028-bfbd438b6ed3 h1:VFk5dHxAQgNpBZCyZR4izXYeGrQyCd4qsZcmcHnQxNQ=
+github.com/algorand/go-algorand-sdk/v2 v2.11.2-0.20260624180028-bfbd438b6ed3/go.mod h1:+AY/uVX/X60O9Ok9HtPWA6DqFRuPl9QWm4scQDmOcFc=
 github.com/algorand/go-codec/codec v1.1.10 h1:zmWYU1cp64jQVTOG8Tw8wa+k0VfwgXIPbnDfiVa+5QA=
 github.com/algorand/go-codec/codec v1.1.10/go.mod h1:YkEx5nmr/zuCeaDYOIhlDg92Lxju8tj2d2NrYqP7g7k=
 github.com/algorand/indexer/v3 v3.9.1-0.20260112183408-2970dcb8ffa7 h1:ZgPY2gncJCFLd3i6+aA5iN/GOdQMFWBx+6abh9x2tgI=


### PR DESCRIPTION
## Summary

`BlockHeader` has now Load field (codec "ld") and CongestionTax ("ct") in go-algorand-sdk. Bump the dependency so the algod importer can decode current nightly blocks; otherwise indexer tests with GetBlock fails with "no matching struct field found when decoding stream map with key ld".

