### PR TITLE
Filter: strip codec tag options when building nested tag paths

### DIFF
--- a/conduit/plugins/processors/filterprocessor/gen/generate.go
+++ b/conduit/plugins/processors/filterprocessor/gen/generate.go
@@ -180,13 +180,19 @@ func recursiveTagFields(theStruct interface{}, ignoreTags map[string]bool, outpu
 		name := field.Name
 		numOutputsBefore := len(output)
 
-		// Lookup codec tag
+		// Lookup codec tag. Only the part before the first comma names the
+		// field, the rest are encoding options like "required" or "omitempty",
+		// which must not become part of the tag path.
 		tagValue, foundTag := field.Tag.Lookup("codec")
+		tagName := strings.Split(tagValue, ",")[0]
+		// A tag that only carries options (`codec:",omitempty"`) names nothing,
+		// so treat it as untagged.
+		foundTag = foundTag && tagName != ""
 
 		if field.Type.Kind() == reflect.Struct {
 			var passedTagLevel []string
 			if foundTag {
-				passedTagLevel = append(tagLevel, tagValue)
+				passedTagLevel = append(tagLevel, tagName)
 			} else {
 				passedTagLevel = tagLevel
 			}
@@ -196,15 +202,7 @@ func recursiveTagFields(theStruct interface{}, ignoreTags map[string]bool, outpu
 		// Add to output if there is a tag, and there were no subtags (i.e. this is a leaf)
 		foundSubtag := numOutputsBefore < len(output)
 		if foundTag && !foundSubtag {
-			vals := strings.Split(tagValue, ",")
-			// Get the first value (the one we care about)
-			tagValue = vals[0]
-			// If it is empty ignore it
-			if tagValue == "" {
-				continue
-			}
-
-			fullTag := strings.Join(append(tagLevel, tagValue), ".")
+			fullTag := strings.Join(append(tagLevel, tagName), ".")
 			if ignoreTags[fullTag] {
 				continue
 			}

--- a/conduit/plugins/processors/filterprocessor/gen/generate_test.go
+++ b/conduit/plugins/processors/filterprocessor/gen/generate_test.go
@@ -54,6 +54,37 @@ func TestIgnoreMiddleTags(t *testing.T) {
 	}, f["parent.child"])
 }
 
+// Codec tags may carry options after the name ("txn,required"). Those options
+// belong to the encoder, not to the tag path, so nested paths and ignore
+// lookups must be built from the name alone.
+func TestTagOptionsStrippedWhenRecursing(t *testing.T) {
+	t.Parallel()
+	testStruct := struct {
+		Parent struct {
+			Child   string `codec:"child,omitempty"`
+			Ignored string `codec:"ignoreme"`
+		} `codec:"parent,required"`
+		Unnamed struct {
+			Deep string `codec:"deep"`
+		} `codec:",omitempty"`
+	}{}
+
+	ignore := map[string]bool{"parent.ignoreme": true}
+	f, errs := getFields(testStruct, ignore)
+	require.Len(t, errs, 0)
+	// parent.ignoreme was ignored, so only child and deep remain.
+	require.Len(t, f, 2)
+	assert.Equal(t, internal.StructField{
+		TagPath:   "parent.child",
+		FieldPath: "Parent.Child",
+	}, f["parent.child"])
+	// A tag with no name contributes nothing to the path.
+	assert.Equal(t, internal.StructField{
+		TagPath:   "deep",
+		FieldPath: "Unnamed.Deep",
+	}, f["deep"])
+}
+
 func TestNoCast(t *testing.T) {
 	t.Parallel()
 	testStruct := struct {


### PR DESCRIPTION
## Problem

`recursiveTagFields` passed the raw `codec` tag value down when recursing into a struct field:

```go
passedTagLevel = append(tagLevel, tagValue)
```

The options after the first comma were only stripped at the leaf. So a struct field tagged `codec:"txn,required"` produced tag paths like `txn,required.fee` instead of `txn.fee`. Two consequences:

- every `ignoreTags` lookup for a nested field under such a parent misses, so fields we intend to exclude get generated
- the generated filter tag name itself carries the encoder option

## Fix

Parse the tag name once, before the recursion branch, and use it for both the nested path and the leaf's `fullTag`. This also removes the duplicated split/empty-check that lived in the leaf branch. A tag that carries only options (`codec:",omitempty"`) names nothing, so it is now treated as untagged at any level rather than only at leaves.

## Test

`TestTagOptionsStrippedWhenRecursing` covers a `codec:"parent,required"` field with an `ignoreTags` entry for `parent.ignoreme`, plus an options-only tag on a nested struct. Against the old code it fails with the exact symptom:

```
map[,omitempty.deep:... parent,required.child:... parent,required.ignoreme:...]
should have 2 item(s), but has 3
```

## Generated output

Re-ran the generator (`go run ../gen/generate.go fields ./generated_signed_txn_map.go ../Filter_tags.md`); `generated_signed_txn_map.go` and `Filter_tags.md` are byte-identical, since no SDK struct-typed field carries tag options today. The fix is preventative for ones that might.