### PR TITLE
Sync: Bump go-algorand-sdk to main for pqsig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 toolchain go1.25.3
 
 require (
-	github.com/algorand/go-algorand-sdk/v2 v2.11.2-0.20260624180028-bfbd438b6ed3
+	github.com/algorand/go-algorand-sdk/v2 v2.11.2-0.20260730212803-2b779fd6c4c3
 	github.com/algorand/go-codec/codec v1.1.10
 	github.com/algorand/indexer/v3 v3.9.1-0.20260112183408-2970dcb8ffa7
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/algorand/avm-abi v0.2.0 h1:bkjsG+BOEcxUcnGSALLosmltE0JZdg+ZisXKx0UDX2k=
 github.com/algorand/avm-abi v0.2.0/go.mod h1:+CgwM46dithy850bpTeHh9MC99zpn2Snirb3QTl2O/g=
-github.com/algorand/go-algorand-sdk/v2 v2.11.2-0.20260624180028-bfbd438b6ed3 h1:VFk5dHxAQgNpBZCyZR4izXYeGrQyCd4qsZcmcHnQxNQ=
-github.com/algorand/go-algorand-sdk/v2 v2.11.2-0.20260624180028-bfbd438b6ed3/go.mod h1:+AY/uVX/X60O9Ok9HtPWA6DqFRuPl9QWm4scQDmOcFc=
+github.com/algorand/go-algorand-sdk/v2 v2.11.2-0.20260730212803-2b779fd6c4c3 h1:YFx42zKIidEVplC4jXKK1I0b0hUSbdd2JgMCl4d3YI0=
+github.com/algorand/go-algorand-sdk/v2 v2.11.2-0.20260730212803-2b779fd6c4c3/go.mod h1:+AY/uVX/X60O9Ok9HtPWA6DqFRuPl9QWm4scQDmOcFc=
 github.com/algorand/go-codec/codec v1.1.10 h1:zmWYU1cp64jQVTOG8Tw8wa+k0VfwgXIPbnDfiVa+5QA=
 github.com/algorand/go-codec/codec v1.1.10/go.mod h1:YkEx5nmr/zuCeaDYOIhlDg92Lxju8tj2d2NrYqP7g7k=
 github.com/algorand/indexer/v3 v3.9.1-0.20260112183408-2970dcb8ffa7 h1:ZgPY2gncJCFLd3i6+aA5iN/GOdQMFWBx+6abh9x2tgI=


### PR DESCRIPTION
Bumps `go-algorand-sdk/v2` from `v2.11.2-0.20260624180028-bfbd438b6ed3` (2026-06-24) to `v2.11.2-0.20260730212803-2b779fd6c4c3` (current `main`).

## Why

The nightly algod now emits the `pqsig` key in `SignedTxn`. The previously pinned SDK predates the post-quantum signature types (added to the SDK on 2026-07-20 in "feat: add post-quantum scheme and signature types"), so go-codec rejects the unknown map key and block import fails outright:

```
importer algod.GetBlock() error getting block for round 34, check node configuration:
error decoding block for round 34: msgpack decode error [pos 2602]:
no matching struct field found when decoding stream map with key pqsig
```

This currently breaks Indexer's e2e suite on every PR, since `e2e_tests/docker/indexer/Dockerfile` builds conduit from `master` and runs it against a `nightly` algod.

The new SDK carries `PQsig PQSig \`codec:"pqsig"\`` on `SignedTxn`, plus the v42 consensus parameter updates.

## Notes

- `go generate ./...` produces no diff — #198 ("Filter: Ignore pqsig") already excludes the PQ signature fields from the filter processor's generated field list, so this bump needed no accompanying regeneration.
- `go build ./...`, `go vet ./...`, and `go test ./...` all pass (the postgres exporter container tests were skipped locally for lack of a Docker daemon).