### PR TITLE
CI: Add nightly workflow running e2e against unpinned test data

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,79 @@
+name: Nightly Tests
+
+on:
+  schedule:
+    - cron: "17 5 * * *"  # Run at 5:17 AM UTC daily
+  workflow_dispatch:
+
+env:
+  # Unlike the PR workflow, the test data is deliberately NOT pinned to a
+  # commit hash. Tracking the latest nightly is what surfaces encoding changes
+  # in go-algorand (new block or transaction fields) against a strict msgpack
+  # decode, which a frozen dataset can never do.
+  CI_E2E_FILENAME: "rel-nightly"
+  CHANNEL: nightly
+  SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+jobs:
+  test_nightly:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+
+      - name: Install go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install algod
+        run: |
+            wget https://raw.githubusercontent.com/algorand/go-algorand/rel/stable/cmd/updater/update.sh && chmod 744 update.sh
+            ./update.sh -i -c "$CHANNEL" -n -d ./ -p "$RUNNER_WORKSPACE/algod_bin"
+            ls "$RUNNER_WORKSPACE/algod_bin"
+            # Make it accessible from runner
+            echo "$RUNNER_WORKSPACE/algod_bin" >> $GITHUB_PATH
+
+      - name: Test for algod on path
+        run: which algod
+
+      - name: Build Conduit
+        run: make
+
+      - name: Run tests
+        run: make test
+
+      - name: Build e2e tests
+        run: pip3 install e2e_tests/
+
+      - name: Run e2e tests (nightly)
+        run: |
+          make e2e-conduit
+
+      - name: Notify Slack on failure
+        if: failure() && env.SLACK_WEBHOOK != ''
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
+          webhook-type: webhook-trigger
+          payload: |
+            {
+              "text": "Conduit Nightly Failure Alert",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "test_nightly Job Failure:\n* Branch: `${{ github.ref_name }}`\n* Run URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
Adds `.github/workflows/nightly.yml`: a scheduled run of the e2e suite against the **latest** nightly test data, rather than a pinned snapshot.

## Why

Conduit's CI is currently structurally unable to detect that go-algorand added a block or transaction field:

- **The PR workflow's data is frozen.** `tests.yml` sets `CI_E2E_FILENAME: "f55ae1c8/rel-nightly"`, so every run replays the same historical blocks. It will never see a new encoding until someone edits that hash by hand.
- **There is no scheduled build.** `tests.yml` triggers only `on: pull_request`, so nothing re-tests between PRs.
- **Unit tests cannot catch this class of bug even in principle.** The importer tests build a block in Go, encode it with the SDK, and decode it with the same SDK. A round-trip through one struct definition passes regardless of what algod actually emits.

And the failure mode is fatal rather than cosmetic, because the SDK decodes with `CodecHandle.ErrorIfNoField = true` — an unknown map key aborts block import entirely.

That combination is what let #199 through: the SDK pin went stale, nightly algod began emitting `pqsig`, and the breakage surfaced only in *Indexer's* e2e (which tracks unpinned `rel-nightly`), several steps removed from its cause here.

## What this does

Mirrors the existing `tests.yml` recipe with two changes:

- `CI_E2E_FILENAME: "rel-nightly"` — unpinned, so it tracks the current nightly. This is the entire point of the workflow, and is called out in a comment so it doesn't get "helpfully" pinned later.
- Runs on `schedule` (05:17 UTC, offset from Indexer's 03:37 nightly) plus `workflow_dispatch` for manual runs. Guarded with `if: github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'`, matching Indexer's convention.

Failures notify Slack via `secrets.SLACK_WEBHOOK`, following the same pattern as `algorand/indexer`'s `ci-nightly.yml`. The step is guarded on `env.SLACK_WEBHOOK != ''`, so it silently no-ops if that secret isn't configured for this repo — no action needed to merge, but the alert is worth wiring up if it isn't set.

Codecov upload is deliberately omitted; nightly coverage numbers would just add noise to the PR-based reports.

## Verification

- YAML parses; triggers, job guard, env, and step list all check out.
- `CI_E2E_FILENAME=rel-nightly make -n e2e-conduit` confirms the override reaches the target (`--s3-source-net rel-nightly`) — the Makefile uses `?=`, which defers to the environment.
- A bare dataset name with no `/` resolves through the `indexer/e2e4` S3 prefix via `firstFromS3Prefix` (`e2e_tests/src/e2e_conduit/fixtures/importers/algod.py:57-77`), which is how Indexer already consumes `rel-nightly`.
- Rebased onto `master` at 415873a, so #199 is included and the first scheduled run should be green rather than tripping over the `pqsig` decode.