### PR TITLE
Sync: Bump indexer for pqsig, stop leaking a pipeline in the CLI test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.25.3
 require (
 	github.com/algorand/go-algorand-sdk/v2 v2.11.2-0.20260730212803-2b779fd6c4c3
 	github.com/algorand/go-codec/codec v1.1.10
-	github.com/algorand/indexer/v3 v3.9.1-0.20260112183408-2970dcb8ffa7
+	github.com/algorand/indexer/v3 v3.9.1-0.20260731152534-4938ea23a3c0
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v4 v4.18.2
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/algorand/go-algorand-sdk/v2 v2.11.2-0.20260730212803-2b779fd6c4c3 h1:
 github.com/algorand/go-algorand-sdk/v2 v2.11.2-0.20260730212803-2b779fd6c4c3/go.mod h1:+AY/uVX/X60O9Ok9HtPWA6DqFRuPl9QWm4scQDmOcFc=
 github.com/algorand/go-codec/codec v1.1.10 h1:zmWYU1cp64jQVTOG8Tw8wa+k0VfwgXIPbnDfiVa+5QA=
 github.com/algorand/go-codec/codec v1.1.10/go.mod h1:YkEx5nmr/zuCeaDYOIhlDg92Lxju8tj2d2NrYqP7g7k=
-github.com/algorand/indexer/v3 v3.9.1-0.20260112183408-2970dcb8ffa7 h1:ZgPY2gncJCFLd3i6+aA5iN/GOdQMFWBx+6abh9x2tgI=
-github.com/algorand/indexer/v3 v3.9.1-0.20260112183408-2970dcb8ffa7/go.mod h1:GrCKOrKnstriaJDi784qxQJILz5q3fARkVa3zDPPrCE=
+github.com/algorand/indexer/v3 v3.9.1-0.20260731152534-4938ea23a3c0 h1:G9TuSzEctFOWkXHQVeBll7QxOcPotyIwViA/1OzXyeY=
+github.com/algorand/indexer/v3 v3.9.1-0.20260731152534-4938ea23a3c0/go.mod h1:UFpuScctU9xYm3oaPd90Eac1rLZzmV7y217cpB9cI2Q=
 github.com/algorand/oapi-codegen v1.12.0-algorand.0 h1:W9PvED+wAJc+9EeXPONnA+0zE9UhynEqoDs4OgAxKhk=
 github.com/algorand/oapi-codegen v1.12.0-algorand.0/go.mod h1:tIWJ9K/qrLDVDt5A1p82UmxZIEGxv2X+uoujdhEAL48=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -34,7 +34,7 @@ const (
 	conduitEnvVar = "CONDUIT_DATA_DIR"
 )
 
-// runConduitCmdWithConfig run the main logic with a supplied conduit config.
+// runConduitCmdWithConfig runs the main logic with a supplied conduit config.
 // Cancelling ctx shuts the pipeline down and makes this return.
 func runConduitCmdWithConfig(ctx context.Context, args *data.Args) error {
 	defer pipeline.HandlePanic(logger)

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -34,8 +34,9 @@ const (
 	conduitEnvVar = "CONDUIT_DATA_DIR"
 )
 
-// runConduitCmdWithConfig run the main logic with a supplied conduit config
-func runConduitCmdWithConfig(args *data.Args) error {
+// runConduitCmdWithConfig run the main logic with a supplied conduit config.
+// Cancelling ctx shuts the pipeline down and makes this return.
+func runConduitCmdWithConfig(ctx context.Context, args *data.Args) error {
 	defer pipeline.HandlePanic(logger)
 
 	if args.ConduitDataDir == "" {
@@ -80,7 +81,6 @@ func runConduitCmdWithConfig(args *data.Args) error {
 		fmt.Println("Writing logs to console.")
 	}
 
-	ctx := context.Background()
 	pline, err := pipeline.MakePipeline(ctx, pCfg, logger)
 	if err != nil {
 		err = fmt.Errorf("pipeline creation error: %w", err)
@@ -149,8 +149,8 @@ See other subcommands for further built in utilities and information.
 
 Detailed documentation is online: https://github.com/algorand/conduit`,
 		Args: cobra.NoArgs,
-		Run: func(_ *cobra.Command, _ []string) {
-			err := runConduitCmdWithConfig(cfg)
+		Run: func(cmd *cobra.Command, _ []string) {
+			err := runConduitCmdWithConfig(cmd.Context(), cfg)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "\nExiting with error:\t%s.\n", err)
 				os.Exit(1)

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"net/http"
@@ -52,7 +53,7 @@ func TestBanner(t *testing.T) {
 		}
 		args := setupDataDir(t, cfg)
 
-		err = runConduitCmdWithConfig(args)
+		err = runConduitCmdWithConfig(context.Background(), args)
 		data, err := os.ReadFile(stdoutFilePath)
 		require.NoError(t, err)
 
@@ -74,7 +75,7 @@ func TestBanner(t *testing.T) {
 
 func TestEmptyDataDir(t *testing.T) {
 	args := data.Args{}
-	err := runConduitCmdWithConfig(&args)
+	err := runConduitCmdWithConfig(context.Background(), &args)
 	require.ErrorContains(t, err, conduitEnvVar)
 }
 
@@ -83,7 +84,7 @@ func TestInvalidLogLevel(t *testing.T) {
 		LogLevel: "invalid",
 	}
 	args := setupDataDir(t, cfg)
-	err := runConduitCmdWithConfig(args)
+	err := runConduitCmdWithConfig(context.Background(), args)
 	require.ErrorContains(t, err, "not a valid log level")
 }
 
@@ -109,7 +110,7 @@ func TestLogFile(t *testing.T) {
 		}
 		args := setupDataDir(t, cfg)
 
-		err = runConduitCmdWithConfig(args)
+		err = runConduitCmdWithConfig(context.Background(), args)
 		require.ErrorContains(t, err, "pipeline creation error")
 		return os.ReadFile(stdoutFilePath)
 	}
@@ -155,8 +156,18 @@ func TestHealthEndpoint(t *testing.T) {
 		}
 		args := setupDataDir(t, cfg)
 
+		// The pipeline must be shut down and fully drained before the subtest
+		// returns. Otherwise it keeps writing metadata into the data dir while
+		// t.TempDir() cleanup is removing it, which fails the test.
+		ctx, cancel := context.WithCancel(context.Background())
+		done := make(chan struct{})
 		go func() {
-			runConduitCmdWithConfig(args)
+			defer close(done)
+			runConduitCmdWithConfig(ctx, args)
+		}()
+		defer func() {
+			cancel()
+			<-done
 		}()
 		time.Sleep(1 * time.Second)
 


### PR DESCRIPTION
Fixes both failure modes seen in the nightly runs since it was added ([Aug 1](https://github.com/algorand/conduit/actions/runs/30687365696) through [Aug 5](https://github.com/algorand/conduit/actions/runs/30980461366)).

### pqsig transactions abort the postgresql exporter

This is the failure the nightly was built to surface, and it reproduces every night that gets as far as e2e (Aug 2, 4, 5 — identical):

```
exporter postgresql handler ... aborting after failing to export round 36:
  AddBlock() err: getSigTypeDelta() err: unable to determine the signature type
  for stxn=&{... PQsig:{Scheme:[102 49] Salt:3 PublicKey:[...] Signature:[...]} ...}
```

Nightly algod now produces transactions signed with post-quantum signatures (`Scheme: "f1"`), with `Sig`, `Msig`, and `Lsig` all blank. `idb.SignatureType` in the pinned indexer only knew sig/msig/lsig.

Indexer `main` fixed this in [219b2118](https://github.com/algorand/indexer/commit/219b2118e3af) ("Update to recognize pqsigs"), so this is just a dependency bump: `v3.9.1-0.20260112183408-2970dcb8ffa7` → `v3.9.1-0.20260731152534-4938ea23a3c0`. Indexer main pins the same go-algorand-sdk revision we already use, so `go mod tidy` produced no other churn. `"pqsig"` fits the existing `keytype varchar(8)`, so no schema migration is involved.

Confirmed against the exact case from the log: a `SignedTxn` with only `PQsig` set now classifies as `pqsig` instead of erroring.

### TestHealthEndpoint leaked a running pipeline

Aug 1 and Aug 3 failed earlier, at `make test` rather than e2e — an unrelated pre-existing flake that can bite PR CI too:

```
--- FAIL: TestHealthEndpoint/API_OFF
    TempDir RemoveAll cleanup: unlinkat /tmp/...: directory not empty
```

The test started the pipeline in a bare goroutine and never stopped it, so it was still writing `metadata.json` into the data dir while `t.TempDir()` cleanup removed it — hence the "directory not empty", plus the accompanying `failed to create temp metadata file: ... no such file or directory` from the leaked pipeline.

It could not be stopped: `runConduitCmdWithConfig` hardcoded `context.Background()`. It now takes a context, which `MakePipeline` already derives its cancelable context from, and the test cancels and waits for the goroutine before returning. The cobra command passes `cmd.Context()`, which cobra defaults to `context.Background()`, so the binary behaves exactly as before (and `ExecuteContext` with signal handling becomes possible later).

### Testing

`go build ./...` and `go vet` clean, `make test` passes, `TestHealthEndpoint` passes 5 consecutive runs. The pqsig path can only be exercised end-to-end by the nightly itself, so it is worth a `workflow_dispatch` run on master once this lands.